### PR TITLE
Add an Uri type alias.

### DIFF
--- a/core/src/extension.rs
+++ b/core/src/extension.rs
@@ -19,13 +19,12 @@ use std::any::Any;
 ///
 ///  An example on how to put it all together:
 ///
-///     use lv2_core::plugin::{Plugin, PluginInfo};
+///     use lv2_core::prelude::*;
 ///     use lv2_core::feature::FeatureContainer;
 ///     use lv2_core::extension::Extension;
 ///     use lv2_core::{UriBound, match_extensions};
 ///
 ///     use std::any::Any;
-///     use std::ffi::{CString, CStr};
 ///
 ///     // ######################
 ///     // Defining the extension
@@ -78,7 +77,7 @@ use std::any::Any;
 ///
 ///         fn run(&mut self, _: &mut ()) {}
 ///
-///         fn extension_data(uri: &CStr) -> Option<&'static dyn Any> {
+///         fn extension_data(uri: &Uri) -> Option<&'static dyn Any> {
 ///             match_extensions![uri, dyn MyExtension]
 ///         }
 ///     }

--- a/core/src/feature.rs
+++ b/core/src/feature.rs
@@ -1,7 +1,7 @@
 //! Additional host functionalities.
-use crate::UriBound;
+use crate::{Uri, UriBound};
 use std::collections::HashMap;
-use std::ffi::{c_void, CStr};
+use std::ffi::c_void;
 
 /// Trait to generalize the feature detection system.
 ///
@@ -69,13 +69,13 @@ impl<'a> Feature<'a> for IsLive {
 
 /// Descriptor of a single host feature.
 pub struct FeatureDescriptor<'a> {
-    uri: &'a CStr,
+    uri: &'a Uri,
     data: *mut c_void,
 }
 
 impl<'a> FeatureDescriptor<'a> {
     /// Return the URI of the feature.
-    pub fn uri(&self) -> &CStr {
+    pub fn uri(&self) -> &Uri {
         self.uri
     }
 
@@ -115,7 +115,7 @@ impl<'a> FeatureDescriptor<'a> {
 ///
 /// Internally, this struct contains a hash map which is filled the raw LV2 feature descriptors. Using this map, methods are defined to identify and retrieve features.
 pub struct FeatureContainer<'a> {
-    internal: HashMap<&'a CStr, *mut c_void>,
+    internal: HashMap<&'a Uri, *mut c_void>,
 }
 
 impl<'a> FeatureContainer<'a> {
@@ -128,7 +128,7 @@ impl<'a> FeatureContainer<'a> {
 
         if !raw.is_null() {
             while !(*feature_ptr).is_null() {
-                let uri = CStr::from_ptr((**feature_ptr).URI);
+                let uri = Uri::from_ptr((**feature_ptr).URI);
                 let data = (**feature_ptr).data;
                 internal_map.insert(uri, data);
                 feature_ptr = feature_ptr.add(1);
@@ -157,8 +157,8 @@ impl<'a> FeatureContainer<'a> {
 
 use std::collections::hash_map;
 use std::iter::Map;
-type HashMapIterator<'a> = hash_map::IntoIter<&'a CStr, *mut c_void>;
-type DescriptorBuildFn<'a> = fn((&'a CStr, *mut c_void)) -> FeatureDescriptor<'a>;
+type HashMapIterator<'a> = hash_map::IntoIter<&'a Uri, *mut c_void>;
+type DescriptorBuildFn<'a> = fn((&'a Uri, *mut c_void)) -> FeatureDescriptor<'a>;
 
 impl<'a> std::iter::IntoIterator for FeatureContainer<'a> {
     type Item = FeatureDescriptor<'a>;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,12 +12,14 @@ pub mod plugin;
 pub mod port;
 pub mod prelude;
 
+pub type Uri = ::std::ffi::CStr;
+pub type UriBuf = ::std::ffi::CString;
+
 /// Trait for types that can be identified by a URI.
 ///
 /// LV2 makes heavy use of URIs to identify resources. This is where this trait comes in: Every type that can be identified by a URI implements this trait, which makes the retrieval of these URIs as easy as the following:
 ///
 ///     use lv2_core::UriBound;
-///     use std::ffi::CStr;
 ///
 ///     // Defining the struct
 ///     pub struct MyStruct {
@@ -46,7 +48,7 @@ pub unsafe trait UriBound {
     /// Construct a `CStr` reference to the URI.
     ///
     /// Assuming that [`URI`](#associatedconstant.URI) is correct, this method constructs a `CStr` reference from the byte slice referenced by `URI`.
-    fn uri() -> &'static std::ffi::CStr {
-        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(Self::URI) }
+    fn uri() -> &'static Uri {
+        unsafe { Uri::from_bytes_with_nul_unchecked(Self::URI) }
     }
 }

--- a/core/src/plugin/info.rs
+++ b/core/src/plugin/info.rs
@@ -1,4 +1,4 @@
-use std::ffi::CStr;
+use crate::Uri;
 use std::os::raw::c_char;
 use std::path::Path;
 use std::str::Utf8Error;
@@ -11,7 +11,7 @@ pub(crate) enum PluginInfoError {
 
 /// Holds various data that is passed from the host at plugin instantiation time.
 pub struct PluginInfo<'a> {
-    plugin_uri: &'a CStr,
+    plugin_uri: &'a Uri,
     bundle_path: &'a Path,
     sample_rate: f64,
 }
@@ -23,15 +23,15 @@ impl<'a> PluginInfo<'a> {
         sample_rate: f64,
     ) -> Result<Self, PluginInfoError> {
         Self::new(
-            CStr::from_ptr((*plugin_descriptor).URI),
-            CStr::from_ptr(bundle_path),
+            Uri::from_ptr((*plugin_descriptor).URI),
+            Uri::from_ptr(bundle_path),
             sample_rate,
         )
     }
 
     pub(crate) fn new(
-        plugin_uri: &'a CStr,
-        bundle_path: &'a CStr,
+        plugin_uri: &'a Uri,
+        bundle_path: &'a Uri,
         sample_rate: f64,
     ) -> Result<Self, PluginInfoError> {
         let bundle_path = Path::new(
@@ -48,7 +48,7 @@ impl<'a> PluginInfo<'a> {
     }
 
     /// The URI of the plugin that is being instantiated.
-    pub fn plugin_uri(&self) -> &CStr {
+    pub fn plugin_uri(&self) -> &Uri {
         self.plugin_uri
     }
 

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -6,8 +6,9 @@ pub use lv2_core_derive::*;
 
 use crate::feature::*;
 use crate::port::*;
+use crate::Uri;
 use std::any::Any;
-use std::ffi::{c_void, CStr};
+use std::ffi::c_void;
 use std::os::raw::c_char;
 use sys::LV2_Handle;
 
@@ -47,7 +48,7 @@ pub trait Plugin: Sized + Send + Sync + 'static {
     /// However, these implemented methods must be passed to the host. This is where this method comes into play: The host will call it with a URI for an extension. Then, it is the plugin's responsibilty to return the extension data to the host.
     ///
     /// In most cases, you can simply use the [`match_extensions`](../macro.match_extensions.html) macro to generate an appropiate method body.
-    fn extension_data(_uri: &CStr) -> Option<&'static dyn Any> {
+    fn extension_data(_uri: &Uri) -> Option<&'static dyn Any> {
         None
     }
 }
@@ -136,7 +137,7 @@ impl<T: Plugin> PluginInstance<T> {
 
     /// Dereference the URI, call the `extension_data` function and return the pointer.
     pub unsafe extern "C" fn extension_data(uri: *const c_char) -> *const c_void {
-        let uri = CStr::from_ptr(uri);
+        let uri = Uri::from_ptr(uri);
         if let Some(data) = T::extension_data(uri) {
             data as *const _ as *const c_void
         } else {

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -2,3 +2,4 @@
 pub use crate::feature::FeatureContainer;
 pub use crate::plugin::{lv2_descriptors, Plugin, PluginInfo, PortContainer};
 pub use crate::port::*;
+pub use crate::Uri;

--- a/core/tests/amp.rs
+++ b/core/tests/amp.rs
@@ -77,13 +77,12 @@ lv2_descriptors! {
 #[test]
 fn test_discovery() {
     use lv2_core_sys::*;
-    use std::ffi::CStr;
 
     unsafe {
         let descriptor: &LV2_Descriptor = lv2_descriptor(0).as_ref().unwrap();
         assert_eq!(
-            CStr::from_ptr(descriptor.URI),
-            CStr::from_bytes_with_nul_unchecked(b"http://lv2plug.in/plugins.rs/example_amp\0")
+            Uri::from_ptr(descriptor.URI),
+            Uri::from_bytes_with_nul_unchecked(b"http://lv2plug.in/plugins.rs/example_amp\0")
         );
         assert_eq!(lv2_descriptor(1), std::ptr::null());
     }

--- a/urid/src/feature.rs
+++ b/urid/src/feature.rs
@@ -1,8 +1,8 @@
 //! Thin but safe wrappers for the URID mapping features.
 use crate::{URIDCache, URID};
 use core::feature::Feature;
+use core::Uri;
 use core::UriBound;
-use std::ffi::CStr;
 use std::os::raw::c_char;
 
 /// Host feature to map URIs to integers
@@ -35,7 +35,7 @@ impl<'a> Map<'a> {
     ///
     ///     use lv2_urid::mapper::URIDMap;
     ///     use lv2_urid::URID;
-    ///     use std::ffi::CStr;
+    ///     use lv2_core::Uri;
     ///
     ///     // Creating a mapping feature.
     ///     // This is normally done by the host.
@@ -43,10 +43,10 @@ impl<'a> Map<'a> {
     ///     let map = raw_interface.map();
     ///
     ///     // Creating the URI and mapping it to it's URID.
-    ///     let uri: &CStr = CStr::from_bytes_with_nul(b"http://lv2plug.in\0").unwrap();
+    ///     let uri: &Uri = Uri::from_bytes_with_nul(b"http://lv2plug.in\0").unwrap();
     ///     let urid: URID = map.map_uri(uri).unwrap();
     ///     assert_eq!(1, urid);
-    pub fn map_uri(&self, uri: &CStr) -> Option<URID> {
+    pub fn map_uri(&self, uri: &Uri) -> Option<URID> {
         let handle = self.internal.handle;
         let uri = uri.as_ptr();
         let urid = unsafe { (self.internal.map.unwrap())(handle, uri) };
@@ -66,7 +66,6 @@ impl<'a> Map<'a> {
     ///     use lv2_core::UriBound;
     ///     use lv2_urid::mapper::URIDMap;
     ///     use lv2_urid::URID;
-    ///     use std::ffi::CStr;
     ///
     ///     struct MyUriBound;
     ///
@@ -129,10 +128,9 @@ impl<'a> Unmap<'a> {
     ///
     /// # Usage example:
     ///
-    ///     use lv2_core::UriBound;
+    ///     use lv2_core::{UriBound, Uri};
     ///     use lv2_urid::mapper::URIDMap;
     ///     use lv2_urid::URID;
-    ///     use std::ffi::CStr;
     ///
     ///     struct MyUriBound;
     ///
@@ -152,15 +150,15 @@ impl<'a> Unmap<'a> {
     ///
     ///     // Mapping the type to it's URID, and then back to it's URI.
     ///     let urid: URID<MyUriBound> = map.map_type::<MyUriBound>().unwrap();
-    ///     let uri: &CStr = unmap.unmap(urid).unwrap();
+    ///     let uri: &Uri = unmap.unmap(urid).unwrap();
     ///     assert_eq!(MyUriBound::uri(), uri);
-    pub fn unmap<T: ?Sized>(&self, urid: URID<T>) -> Option<&CStr> {
+    pub fn unmap<T: ?Sized>(&self, urid: URID<T>) -> Option<&Uri> {
         let handle = self.internal.handle;
         let uri_ptr = unsafe { (self.internal.unmap.unwrap())(handle, urid.get()) };
         if uri_ptr.is_null() {
             None
         } else {
-            Some(unsafe { CStr::from_ptr(uri_ptr) })
+            Some(unsafe { Uri::from_ptr(uri_ptr) })
         }
     }
 }


### PR DESCRIPTION
This PR brings back the `Uri` (and `UriBuf`) types, but as simple type aliases instead of newtype wrappers.

This does not add any boilerplate (in both the implementing and user side of things), and allows e.g. this:

```rust
fn unmap(&self, urid: URID) -> &CStr { /* ... */ }
```

to become this:

```rust
fn unmap(&self, urid: URID) -> &Uri { /* ... */ }
```

This has the advantage to make all APIs much clearer just by looking at the function signatures, as it is quite odd to be handling FFI types in normal (high-level, safe) APIs, especially for newer users.