### PR TITLE
Refactoring the feature system to remove the `cast_feature_ref` function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ jobs:
         - rustup component add clippy
         - cargo install --force cargo-audit
       script:
-        - cargo build --all --verbose
+        - cargo build --all --all-targets --all-features --verbose
         - cargo audit
-        - cargo clippy --all-targets --all-features -- -D warnings
+        - cargo clippy --all --all-targets --all-features -- -D warnings
         - cargo fmt --all -- --check
 
 matrix:
@@ -34,6 +34,6 @@ matrix:
   fast_finish: true
 
 script:
-  - cargo build --all --verbose
+  - cargo build --all --all-targets --all-features --verbose
   - cargo build --examples --verbose
-  - cargo test --all --verbose --all-features
+  - cargo test --all --all-targets --all-features --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
         - rustup component add clippy
         - cargo install --force cargo-audit
       script:
-        - cargo build --all --all-targets --all-features --verbose
+        - cargo build --all --all-features --verbose
         - cargo audit
         - cargo clippy --all --all-targets --all-features -- -D warnings
         - cargo fmt --all -- --check
@@ -34,6 +34,6 @@ matrix:
   fast_finish: true
 
 script:
-  - cargo build --all --all-targets --all-features --verbose
+  - cargo build --all --all-features --verbose
   - cargo build --examples --verbose
-  - cargo test --all --all-targets --all-features --verbose
+  - cargo test --all --all-features --verbose

--- a/core/derive/src/feature_collection_derive.rs
+++ b/core/derive/src/feature_collection_derive.rs
@@ -53,7 +53,7 @@ impl<'a> FeatureCollectionStruct<'a> {
             .lifetimes()
             .next()
             .map(|l| l.lifetime.clone())
-            .unwrap_or(Lifetime::new("'static", Span::call_site()));
+            .unwrap_or_else(|| Lifetime::new("'static", Span::call_site()));
 
         (quote! {
             impl#generics FeatureCollection<#lifetime> for #struct_name#generics {

--- a/core/derive/src/feature_collection_derive.rs
+++ b/core/derive/src/feature_collection_derive.rs
@@ -1,7 +1,8 @@
 use proc_macro::TokenStream;
+use syn::export::Span;
 use syn::Field;
 use syn::{parse_macro_input, Data, DataStruct, Ident};
-use syn::{DeriveInput, Generics};
+use syn::{DeriveInput, Generics, Lifetime};
 
 struct FeatureCollectionField<'a> {
     identifier: &'a Ident,
@@ -45,11 +46,20 @@ impl<'a> FeatureCollectionStruct<'a> {
     fn make_implementation(&self) -> TokenStream {
         let struct_name = self.struct_name;
         let generics = self.generics;
-        let first_generic = self.generics.lifetimes().next().map(|l| &l.lifetime);
         let retrievals = self.fields.iter().map(|field| field.make_retrieval());
+        // retrieve the first lifetime of the struct, or set it to `'static` if there is none.
+        let lifetime = self
+            .generics
+            .lifetimes()
+            .next()
+            .map(|l| l.lifetime.clone())
+            .unwrap_or(Lifetime::new("'static", Span::call_site()));
+
         (quote! {
-            impl#generics FeatureCollection<#first_generic> for #struct_name#generics {
-                fn from_container(container: &mut FeatureContainer<#first_generic>) -> Result<Self, MissingFeatureError> {
+            impl#generics FeatureCollection<#lifetime> for #struct_name#generics {
+                fn from_container(
+                    container: &mut FeatureContainer<#lifetime>
+                ) -> Result<Self, MissingFeatureError> {
                     Ok(Self {
                         #(#retrievals)*
                     })

--- a/core/src/feature/container.rs
+++ b/core/src/feature/container.rs
@@ -77,7 +77,7 @@ impl<'a> FeatureCollection<'a> for FeatureContainer<'a> {
     }
 }
 
-/// A trait to allow arbitrary types to be potentially created from a feature resolution.
+/// A trait to allow arbitrary types to be potentially created from feature resolution.
 ///
 /// Any type present in a `FeatureCollection` must implement this trait.
 ///

--- a/core/src/feature/core_features.rs
+++ b/core/src/feature/core_features.rs
@@ -4,6 +4,7 @@
 
 use crate::feature::Feature;
 use crate::UriBound;
+use std::ffi::c_void;
 
 /// Marker feature to signal that the plugin can run in a hard real-time environment.
 pub struct HardRTCapable;
@@ -12,7 +13,11 @@ unsafe impl UriBound for HardRTCapable {
     const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__hardRTCapable;
 }
 
-unsafe impl<'a> Feature<'a> for HardRTCapable {}
+unsafe impl Feature for HardRTCapable {
+    unsafe fn from_feature_ptr(_feature: *const c_void) -> Option<Self> {
+        Some(Self)
+    }
+}
 
 /// Marker feature to signal the host to avoid in-place operation.
 ///
@@ -23,7 +28,11 @@ unsafe impl UriBound for InPlaceBroken {
     const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__inPlaceBroken;
 }
 
-unsafe impl<'a> Feature<'a> for InPlaceBroken {}
+unsafe impl<'a> Feature for InPlaceBroken {
+    unsafe fn from_feature_ptr(_feature: *const c_void) -> Option<Self> {
+        Some(Self)
+    }
+}
 
 /// Marker feature to signal the host to only run the plugin in a live environment.
 pub struct IsLive;
@@ -32,4 +41,8 @@ unsafe impl UriBound for IsLive {
     const URI: &'static [u8] = ::lv2_core_sys::LV2_CORE__isLive;
 }
 
-unsafe impl<'a> Feature<'a> for IsLive {}
+unsafe impl<'a> Feature for IsLive {
+    unsafe fn from_feature_ptr(_feature: *const c_void) -> Option<Self> {
+        Some(Self)
+    }
+}

--- a/core/src/feature/descriptor.rs
+++ b/core/src/feature/descriptor.rs
@@ -3,32 +3,6 @@
 use crate::feature::Feature;
 use std::ffi::{c_void, CStr};
 
-/// A dummy pointer to be used to represent zero-sized features.
-///
-/// See the `cast_feature_ref` function below for details.
-static DUMMY_FEATURE_POINTER: () = ();
-
-/// An helper functions that casts a raw feature pointer to a Rust reference to the given feature
-/// type.
-/// If the given pointer is null, this function returns `None`.
-///
-/// This function does an additional check to handle the case where the reference is null but the
-/// Feature type is zero-sized (examples include `HardRTCapable` or `InPlaceBroken`).
-/// If that is the case, a reference to a dummy value is returned instead, which is just as invalid
-/// to read but is non-zero at least.
-///
-/// C LV2 hosts legitimately do this because they have literally nowhere to point to, but in Rust
-/// creating a null reference is instant Undefined Behavior even if the reference itself is never
-/// read and/or zero-sized (e.g. because of `Option`).
-#[inline]
-pub unsafe fn cast_feature_ref<'a, T: Feature<'a>>(feature: *const c_void) -> Option<&'a T> {
-    if ::std::mem::size_of::<T>() == 0 && feature.is_null() {
-        Some(&*(&DUMMY_FEATURE_POINTER as *const () as *const T))
-    } else {
-        (feature as *const T).as_ref()
-    }
-}
-
 /// Descriptor of a single host feature.
 ///
 /// This struct is slightly different from the raw `LV2_Feature` struct, as the length of the
@@ -50,20 +24,16 @@ impl<'a> FeatureDescriptor<'a> {
     }
 
     /// Evaluate whether this object describes the given feature.
-    pub fn is_feature<T: Feature<'a>>(&self) -> bool {
+    pub fn is_feature<T: Feature>(&self) -> bool {
         self.uri == T::uri()
     }
 
-    /// Try to return a reference the data of the feature.
+    /// Try to return a feature struct instance from the internal data.
     ///
     /// If this object describes the requested feature, it will be created from the raw data. This operation consumes the descriptor since it would be possible to have multiple features instances otherwise.
     ///
-    /// If the feature construction fails, or if the pointer is `null`, the descriptor will be returned again.
-    pub fn into_feature<T: Feature<'a>>(self) -> Result<&'a T, Self> {
-        if self.uri == T::uri() {
-            unsafe { cast_feature_ref(self.data) }.ok_or(self)
-        } else {
-            Err(self)
-        }
+    /// If the feature construction fails, the descriptor will be returned again.
+    pub fn into_feature<T: Feature>(self) -> Result<T, Self> {
+        unsafe { T::from_feature_ptr(self.data) }.ok_or(self)
     }
 }

--- a/core/src/feature/mod.rs
+++ b/core/src/feature/mod.rs
@@ -75,6 +75,7 @@ impl<'a> FeatureCollection<'a> for () {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use crate::feature::FeatureContainer;
     use crate::{feature::*, plugin::*, UriBound};

--- a/core/tests/amp.rs
+++ b/core/tests/amp.rs
@@ -36,7 +36,7 @@ impl Plugin for Amp {
             plugin_info.bundle_path().to_str().unwrap(),
             "/home/lv2/amp.lv2/"
         );
-        assert_eq!(plugin_info.sample_rate(), 44100.0);
+        assert_eq!(plugin_info.sample_rate() as u32, 44100);
 
         // Finding and verifying all features.
         assert!(features.is_live.is_none());
@@ -147,6 +147,6 @@ fn test_plugin() {
 
     // Verifying the data.
     for i in 0..128 {
-        assert_eq!(input[i] * gain, output[i]);
+        assert!((input[i] * gain - output[i]).abs() < std::f32::EPSILON);
     }
 }

--- a/core/tests/amp.rs
+++ b/core/tests/amp.rs
@@ -16,14 +16,14 @@ struct AmpPorts {
 }
 
 #[derive(FeatureCollection)]
-struct Features<'a> {
-    rt_capable: &'a HardRTCapable,
-    is_live: Option<&'a IsLive>,
+struct Features {
+    _rt_capable: HardRTCapable,
+    is_live: Option<IsLive>,
 }
 
 impl Plugin for Amp {
     type Ports = AmpPorts;
-    type Features = Features<'static>;
+    type Features = Features;
 
     #[inline]
     fn new(plugin_info: &PluginInfo, features: Features) -> Self {
@@ -39,7 +39,6 @@ impl Plugin for Amp {
         assert_eq!(plugin_info.sample_rate(), 44100.0);
 
         // Finding and verifying all features.
-        assert_ne!(features.rt_capable as *const _, std::ptr::null());
         assert!(features.is_live.is_none());
 
         Amp { activated: false }

--- a/urid/src/feature.rs
+++ b/urid/src/feature.rs
@@ -49,8 +49,9 @@ impl<'a> Map<'a> {
     ///     let uri = Uri::from_bytes_with_nul(b"http://lv2plug.in\0").unwrap();
     ///
     ///     // Use the `map` feature provided by the host:
-    ///     # let mapper = HashURIDMapper::new().make_map_interface();
-    ///     # let map = lv2_urid::feature::Map::new(&mapper.map);
+    ///     # let mut mapper = Box::pin(HashURIDMapper::new());
+    ///     # let host_map = mapper.as_mut().make_map_interface();
+    ///     # let map = lv2_urid::feature::Map::new(&host_map);
     ///     let urid: URID = map.map_uri(uri).unwrap();
     ///     assert_eq!(1, urid);
     pub fn map_uri(&self, uri: &Uri) -> Option<URID> {
@@ -75,8 +76,9 @@ impl<'a> Map<'a> {
     ///     }
     ///
     ///     // Use the `map` feature provided by the host:
-    ///     # let mapper = HashURIDMapper::new().make_map_interface();
-    ///     # let map = lv2_urid::feature::Map::new(&mapper.map);
+    ///     # let mut mapper = Box::pin(HashURIDMapper::new());
+    ///     # let host_map = mapper.as_mut().make_map_interface();
+    ///     # let map = lv2_urid::feature::Map::new(&host_map);
     ///     let urid: URID<MyUriBound> = map.map_type::<MyUriBound>().unwrap();
     ///     assert_eq!(1, urid);
     pub fn map_type<T: UriBound + ?Sized>(&self) -> Option<URID<T>> {
@@ -137,11 +139,11 @@ impl<'a> Unmap<'a> {
     ///     }
     ///
     ///     // Using the `map` and `unmap` features provided by the host:
-    ///     # let mapper = HashURIDMapper::new();
-    ///     # let host_map = mapper.make_map_interface();
-    ///     # let host_unmap = mapper.make_unmap_interface();
-    ///     # let map = lv2_urid::feature::Map::new(&host_map.map);
-    ///     # let unmap = lv2_urid::feature::Unmap::new(&host_unmap.unmap);
+    ///     # let mut mapper = Box::pin(HashURIDMapper::new());
+    ///     # let host_map = mapper.as_mut().make_map_interface();
+    ///     # let host_unmap = mapper.as_mut().make_unmap_interface();
+    ///     # let map = lv2_urid::feature::Map::new(&host_map);
+    ///     # let unmap = lv2_urid::feature::Unmap::new(&host_unmap);
     ///     let urid: URID<MyUriBound> = map.map_type::<MyUriBound>().unwrap();
     ///     let uri: &Uri = unmap.unmap(urid).unwrap();
     ///     assert_eq!(MyUriBound::uri(), uri);

--- a/urid/src/feature.rs
+++ b/urid/src/feature.rs
@@ -8,6 +8,7 @@ use std::ffi::c_void;
 use std::os::raw::c_char;
 
 /// Host feature to map URIs to integers
+#[repr(transparent)]
 pub struct Map<'a> {
     internal: &'a sys::LV2_URID_Map,
 }
@@ -98,6 +99,7 @@ impl<'a> Map<'a> {
 }
 
 /// Host feature to revert the URI -> URID mapping.
+#[repr(transparent)]
 pub struct Unmap<'a> {
     internal: &'a sys::LV2_URID_Unmap,
 }

--- a/urid/src/feature.rs
+++ b/urid/src/feature.rs
@@ -39,6 +39,7 @@ impl<'a> Map<'a> {
     ///     # #![cfg(feature = "host")]
     ///     # use lv2_core::prelude::*;
     ///     # use lv2_urid::prelude::*;
+    ///     # use lv2_urid::mapper::*;
     ///     struct MyUriBound;
     ///
     ///     unsafe impl UriBound for MyUriBound {
@@ -51,7 +52,7 @@ impl<'a> Map<'a> {
     ///     // Use the `map` feature provided by the host:
     ///     # let mut mapper = Box::pin(HashURIDMapper::new());
     ///     # let host_map = mapper.as_mut().make_map_interface();
-    ///     # let map = lv2_urid::feature::Map::new(&host_map);
+    ///     # let map = Map::new(&host_map);
     ///     let urid: URID = map.map_uri(uri).unwrap();
     ///     assert_eq!(1, urid);
     pub fn map_uri(&self, uri: &Uri) -> Option<URID> {
@@ -68,6 +69,7 @@ impl<'a> Map<'a> {
     ///     # #![cfg(feature = "host")]
     ///     # use lv2_core::prelude::*;
     ///     # use lv2_urid::prelude::*;
+    ///     # use lv2_urid::mapper::*;
     ///     # use std::ffi::CStr;
     ///     struct MyUriBound;
     ///
@@ -78,7 +80,7 @@ impl<'a> Map<'a> {
     ///     // Use the `map` feature provided by the host:
     ///     # let mut mapper = Box::pin(HashURIDMapper::new());
     ///     # let host_map = mapper.as_mut().make_map_interface();
-    ///     # let map = lv2_urid::feature::Map::new(&host_map);
+    ///     # let map = Map::new(&host_map);
     ///     let urid: URID<MyUriBound> = map.map_type::<MyUriBound>().unwrap();
     ///     assert_eq!(1, urid);
     pub fn map_type<T: UriBound + ?Sized>(&self) -> Option<URID<T>> {
@@ -132,6 +134,7 @@ impl<'a> Unmap<'a> {
     ///     # #![cfg(feature = "host")]
     ///     # use lv2_core::prelude::*;
     ///     # use lv2_urid::prelude::*;
+    ///     # use lv2_urid::mapper::*;
     ///     struct MyUriBound;
     ///
     ///     unsafe impl UriBound for MyUriBound {
@@ -142,8 +145,8 @@ impl<'a> Unmap<'a> {
     ///     # let mut mapper = Box::pin(HashURIDMapper::new());
     ///     # let host_map = mapper.as_mut().make_map_interface();
     ///     # let host_unmap = mapper.as_mut().make_unmap_interface();
-    ///     # let map = lv2_urid::feature::Map::new(&host_map);
-    ///     # let unmap = lv2_urid::feature::Unmap::new(&host_unmap);
+    ///     # let map = Map::new(&host_map);
+    ///     # let unmap = Unmap::new(&host_unmap);
     ///     let urid: URID<MyUriBound> = map.map_type::<MyUriBound>().unwrap();
     ///     let uri: &Uri = unmap.unmap(urid).unwrap();
     ///     assert_eq!(MyUriBound::uri(), uri);

--- a/urid/src/mapper.rs
+++ b/urid/src/mapper.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 pub struct MapInterface<T: URIDMapper> {
     pub mapper: Pin<Box<T>>,
     pub map: Pin<Box<sys::LV2_URID_Map>>,
-    pub feature: core::sys::LV2_Feature,
+    pub feature: Pin<Box<core::sys::LV2_Feature>>,
 }
 
 /// Interface container for the unmap feature.
@@ -22,7 +22,7 @@ pub struct MapInterface<T: URIDMapper> {
 pub struct UnmapInterface<T: URIDMapper> {
     pub mapper: Pin<Box<T>>,
     pub unmap: Pin<Box<sys::LV2_URID_Unmap>>,
-    pub feature: core::sys::LV2_Feature,
+    pub feature: Pin<Box<core::sys::LV2_Feature>>,
 }
 
 /// A trait to represent an implementation of an URI <-> URID mapper, i.e. that can map an URI
@@ -90,10 +90,10 @@ pub trait URIDMapper: Clone + Unpin + Sized {
             handle: mapper.as_mut().get_mut() as *mut Self as *mut c_void,
             map: Some(Self::extern_map),
         });
-        let feature = core::sys::LV2_Feature {
+        let feature = Box::pin(core::sys::LV2_Feature {
             URI: sys::LV2_URID__map.as_ptr() as *const c_char,
             data: map.as_mut().get_mut() as *mut sys::LV2_URID_Map as *mut c_void,
-        };
+        });
         MapInterface {
             mapper,
             map,
@@ -142,10 +142,10 @@ pub trait URIDMapper: Clone + Unpin + Sized {
             handle: mapper.as_mut().get_mut() as *mut Self as *mut c_void,
             unmap: Some(Self::extern_unmap),
         });
-        let feature = core::sys::LV2_Feature {
+        let feature = Box::pin(core::sys::LV2_Feature {
             URI: sys::LV2_URID__unmap.as_ptr() as *const c_char,
             data: unmap.as_mut().get_mut() as *mut sys::LV2_URID_Unmap as *mut c_void,
-        };
+        });
         UnmapInterface {
             mapper,
             unmap,

--- a/urid/src/urid.rs
+++ b/urid/src/urid.rs
@@ -24,7 +24,7 @@ where
 ///
 ///     # #![cfg(feature = "host")]
 ///     # use lv2_core::UriBound;
-///     # use lv2_urid::{URID, URIDCache};
+///     # use lv2_urid::{URID, URIDCache, mapper::{HashURIDMapper, URIDMapper}};
 ///     # use std::ffi::CStr;
 ///     // Defining all URI bounds.
 ///     struct MyTypeA;
@@ -46,9 +46,11 @@ where
 ///         my_type_b: URID<MyTypeB>,
 ///     }
 ///
-///     # let mapper = lv2_urid::mapper::HashURIDMapper::new();
-///     # let map = lv2_urid::feature::Map::new(&mapper);
-///     # let unmap = lv2_urid::feature::Unmap::new(&mapper);
+///     # let mapper = HashURIDMapper::new();
+///     # let host_map = mapper.make_map_interface();
+///     # let host_unmap = mapper.make_unmap_interface();
+///     # let map = lv2_urid::feature::Map::new(&host_map.map);
+///     # let unmap = lv2_urid::feature::Unmap::new(&host_unmap.unmap);
 ///     // Populating the cache, Using the `map` and `unmap` features provided by the host:
 ///     let cache = MyCache::from_map(&map).unwrap();
 ///

--- a/urid/src/urid.rs
+++ b/urid/src/urid.rs
@@ -25,6 +25,7 @@ where
 ///     # #![cfg(feature = "host")]
 ///     # use lv2_core::prelude::*;
 ///     # use lv2_urid::prelude::*;
+///     # use lv2_urid::mapper::*;
 ///     # use std::ffi::CStr;
 ///     // Defining all URI bounds.
 ///     struct MyTypeA;
@@ -49,8 +50,8 @@ where
 ///     # let mut mapper = Box::pin(HashURIDMapper::new());
 ///     # let host_map = mapper.as_mut().make_map_interface();
 ///     # let host_unmap = mapper.as_mut().make_unmap_interface();
-///     # let map = lv2_urid::feature::Map::new(&host_map);
-///     # let unmap = lv2_urid::feature::Unmap::new(&host_unmap);
+///     # let map = Map::new(&host_map);
+///     # let unmap = Unmap::new(&host_unmap);
 ///     // Populating the cache, Using the `map` and `unmap` features provided by the host:
 ///     let cache = MyCache::from_map(&map).unwrap();
 ///

--- a/urid/src/urid.rs
+++ b/urid/src/urid.rs
@@ -46,11 +46,11 @@ where
 ///         my_type_b: URID<MyTypeB>,
 ///     }
 ///
-///     # let mapper = HashURIDMapper::new();
-///     # let host_map = mapper.make_map_interface();
-///     # let host_unmap = mapper.make_unmap_interface();
-///     # let map = lv2_urid::feature::Map::new(&host_map.map);
-///     # let unmap = lv2_urid::feature::Unmap::new(&host_unmap.unmap);
+///     # let mut mapper = Box::pin(HashURIDMapper::new());
+///     # let host_map = mapper.as_mut().make_map_interface();
+///     # let host_unmap = mapper.as_mut().make_unmap_interface();
+///     # let map = lv2_urid::feature::Map::new(&host_map);
+///     # let unmap = lv2_urid::feature::Unmap::new(&host_unmap);
 ///     // Populating the cache, Using the `map` and `unmap` features provided by the host:
 ///     let cache = MyCache::from_map(&map).unwrap();
 ///

--- a/urid/tests/urid.rs
+++ b/urid/tests/urid.rs
@@ -4,7 +4,7 @@ extern crate lv2_core as core;
 extern crate lv2_urid as urid;
 
 use core::prelude::*;
-use urid::mapper::HashURIDMapper;
+use urid::mapper::{HashURIDMapper, URIDMapper};
 use urid::prelude::*;
 
 struct MyTypeA;

--- a/urid/tests/urid.rs
+++ b/urid/tests/urid.rs
@@ -22,9 +22,9 @@ unsafe impl UriBound for MyTypeB {
 
 #[test]
 fn test_map() {
-    let mapper = HashURIDMapper::new();
-    let host_map = mapper.make_map_interface();
-    let map_feature = Map::new(&host_map.map);
+    let mut mapper = Box::pin(HashURIDMapper::new());
+    let host_map = mapper.as_mut().make_map_interface();
+    let map_feature = Map::new(&host_map);
 
     assert_eq!(1, map_feature.map_uri(MyTypeA::uri()).unwrap());
     assert_eq!(1, map_feature.map_type::<MyTypeA>().unwrap());
@@ -38,11 +38,11 @@ fn test_map() {
 
 #[test]
 fn test_unmap() {
-    let mapper = HashURIDMapper::new();
-    let host_map = mapper.make_map_interface();
-    let host_unmap = mapper.make_unmap_interface();
-    let map_feature = Map::new(&host_map.map);
-    let unmap_feature = Unmap::new(&host_unmap.unmap);
+    let mut mapper = Box::pin(HashURIDMapper::new());
+    let host_map = mapper.as_mut().make_map_interface();
+    let host_unmap = mapper.as_mut().make_unmap_interface();
+    let map_feature = Map::new(&host_map);
+    let unmap_feature = Unmap::new(&host_unmap);
 
     let (type_a, type_b) = {
         (
@@ -63,9 +63,9 @@ struct MyURIDCache {
 
 #[test]
 fn test_cache() {
-    let mapper = HashURIDMapper::new();
-    let host_map = mapper.make_map_interface();
-    let map_feature = Map::new(&host_map.map);
+    let mut mapper = Box::pin(HashURIDMapper::new());
+    let host_map = mapper.as_mut().make_map_interface();
+    let map_feature = Map::new(&host_map);
     let cache = MyURIDCache::from_map(&map_feature).unwrap();
 
     assert_eq!(1, cache.type_a);

--- a/urid/tests/urid.rs
+++ b/urid/tests/urid.rs
@@ -5,7 +5,7 @@ extern crate lv2_urid as urid;
 
 use core::UriBound;
 use urid::feature::*;
-use urid::mapper::HashURIDMapper;
+use urid::mapper::*;
 use urid::*;
 
 struct MyTypeA;
@@ -22,8 +22,9 @@ unsafe impl UriBound for MyTypeB {
 
 #[test]
 fn test_map() {
-    let host_map = HashURIDMapper::new();
-    let map_feature = Map::new(&host_map);
+    let mapper = HashURIDMapper::new();
+    let host_map = mapper.make_map_interface();
+    let map_feature = Map::new(&host_map.map);
 
     assert_eq!(1, map_feature.map_uri(MyTypeA::uri()).unwrap());
     assert_eq!(1, map_feature.map_type::<MyTypeA>().unwrap());
@@ -37,9 +38,11 @@ fn test_map() {
 
 #[test]
 fn test_unmap() {
-    let host_map = HashURIDMapper::new();
-    let map_feature = Map::new(&host_map);
-    let unmap_feature = Unmap::new(&host_map);
+    let mapper = HashURIDMapper::new();
+    let host_map = mapper.make_map_interface();
+    let host_unmap = mapper.make_unmap_interface();
+    let map_feature = Map::new(&host_map.map);
+    let unmap_feature = Unmap::new(&host_unmap.unmap);
 
     let (type_a, type_b) = {
         (
@@ -60,8 +63,9 @@ struct MyURIDCache {
 
 #[test]
 fn test_cache() {
-    let host_map = HashURIDMapper::new();
-    let map_feature = Map::new(&host_map);
+    let mapper = HashURIDMapper::new();
+    let host_map = mapper.make_map_interface();
+    let map_feature = Map::new(&host_map.map);
     let cache = MyURIDCache::from_map(&map_feature).unwrap();
 
     assert_eq!(1, cache.type_a);


### PR DESCRIPTION
Okay, this is a bit weird because I'm reverting some of your changes, but I have good reasons to do so:

At first, I didn't like the `cast_feature_ref` function because it is written without a context, like a type or trait. But secondly and more importantly, it creates a dummy reference to a generally unknown but zero-sized type if the provided pointer points to null. This is very wrong since the reference isn't actually of the given type and therefore, it technically isn't valid.

The first thing could easily be fixed: Move that function inside the `Feature` trait and you're done. The second thing didn't went so easy, because it's roots lie in a design decision: The feature container always has to contain references to the features and this simply doesn't work: Some feature's data pointer does not point to null because it's just a flag, it points to null because there simply is no data to reference. Creating a dummy feature reference in this context is not the right thing to do and also removes freedom from the feature implementer: What if the host does not provide data, but the implementer wants to store it's own data anyway? This would simply not work with this solution.

Therefore, I needed to refactor: Now, every feature has to implement a method that tries to construct the feature struct instance from a data pointer. If the data pointer is used, it has to be stored inside the feature struct as a reference, if not, not. All semantics of the retrieval are contained in this method, which provides maximum flexibility. The derive macro is capable of handling features with and without lifetimes, even complete feature collections without lifetimes. 

On the plugin's side of things, this went relatively easy, but when I started to port the URID module, I ran into problems regarding the host code: It very much depended on the raw features being more or less the same as the wrapper features, which already felt a bit shaky and now didn't work anymore. I needed to rework that too.

This also gave me the opportunity to introduce pins to the system: Since we store a lot of raw pointers to things, the compiler does not assure that they are always valid. Therefore, we have to do that on our own by pinning the pointees. First, we create the mapper and then create the interfaces. These interfaces contain a clone of the mapper, the raw feature, and the feature descriptor, all boxed and pinned. By the way, the map and unmap interfaces are split because having two structs containing mutable pointers to the same value is against the spirit, maybe even against the rules of Rust. The only way the internal pointers may become invalid is when the boxes are dropped, which we can't influence and would be done by the actual host.

The overall process is maybe still a bit rough and could be smoothed out, but it points in a good direction on how to handle host code. However, this would be a topic for another PR.