### PR TITLE
Improving the preludes

### DIFF
--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -1,11 +1,11 @@
 //! LV2 specification for measuring unit definitions.
 //!
 //! The original [specification](http://lv2plug.in/ns/extensions/units/units.html) contains means to describe units for LV2 values in RDF files. This implementation is focused on the stock units defined by the specification by binding them to marker types.
-pub extern crate lv2_core as core;
-pub extern crate lv2_units_sys as sys;
-pub extern crate lv2_urid as urid;
+extern crate lv2_core as core;
+extern crate lv2_units_sys as sys;
+extern crate lv2_urid as urid;
 
-use urid::*;
+use urid::prelude::*;
 
 /// All unit URI bounds.
 pub mod units {
@@ -161,4 +161,10 @@ pub struct UnitURIDCache {
     pub percent: URID<Percent>,
     pub s: URID<Second>,
     pub semitone: URID<Semitone>,
+}
+
+/// Prelude of `lv2_units` for wildcard usage.
+pub mod prelude {
+    pub use crate::units::*;
+    pub use crate::UnitURIDCache;
 }

--- a/urid/derive/src/urid_cache_derive.rs
+++ b/urid/derive/src/urid_cache_derive.rs
@@ -19,7 +19,7 @@ pub fn urid_cache_derive_impl(input: TokenStream) -> TokenStream {
 
     let implementation = quote! {
         impl ::lv2_urid::URIDCache for #struct_name {
-            fn from_map(map: &::lv2_urid::feature::Map) -> Option<Self> {
+            fn from_map(map: &::lv2_urid::Map) -> Option<Self> {
                 Some(Self {
                     #(#field_inits)*
                 })

--- a/urid/src/feature.rs
+++ b/urid/src/feature.rs
@@ -54,8 +54,8 @@ impl<'a> Map<'a> {
     ///
     /// # Usage example:
     ///     # #![cfg(feature = "host")]
-    ///     # use lv2_core::{Uri, UriBound};
-    ///     # use lv2_urid::URID;
+    ///     # use lv2_core::prelude::*;
+    ///     # use lv2_urid::prelude::*;
     ///     struct MyUriBound;
     ///
     ///     unsafe impl UriBound for MyUriBound {
@@ -67,7 +67,7 @@ impl<'a> Map<'a> {
     ///
     ///     // Use the `map` feature provided by the host:
     ///     # let mapper = lv2_urid::mapper::HashURIDMapper::new();
-    ///     # let map = lv2_urid::feature::Map::new(&mapper);
+    ///     # let map = lv2_urid::Map::new(&mapper);
     ///     let urid: URID = map.map_uri(uri).unwrap();
     ///     assert_eq!(1, urid);
     pub fn map_uri(&self, uri: &Uri) -> Option<URID> {
@@ -82,8 +82,8 @@ impl<'a> Map<'a> {
     ///
     /// # Usage example:
     ///     # #![cfg(feature = "host")]
-    ///     # use lv2_core::UriBound;
-    ///     # use lv2_urid::URID;
+    ///     # use lv2_core::prelude::*;
+    ///     # use lv2_urid::prelude::*;
     ///     # use std::ffi::CStr;
     ///     struct MyUriBound;
     ///
@@ -93,7 +93,7 @@ impl<'a> Map<'a> {
     ///
     ///     // Use the `map` feature provided by the host:
     ///     # let mapper = lv2_urid::mapper::HashURIDMapper::new();
-    ///     # let map = lv2_urid::feature::Map::new(&mapper);
+    ///     # let map = lv2_urid::Map::new(&mapper);
     ///     let urid: URID<MyUriBound> = map.map_type::<MyUriBound>().unwrap();
     ///     assert_eq!(1, urid);
     pub fn map_type<T: UriBound + ?Sized>(&self) -> Option<URID<T>> {
@@ -163,8 +163,8 @@ impl<'a> Unmap<'a> {
     ///
     /// # Usage example:
     ///     # #![cfg(feature = "host")]
-    ///     # use lv2_core::{Uri, UriBound};
-    ///     # use lv2_urid::URID;
+    ///     # use lv2_core::prelude::*;
+    ///     # use lv2_urid::prelude::*;
     ///     struct MyUriBound;
     ///
     ///     unsafe impl UriBound for MyUriBound {
@@ -173,8 +173,8 @@ impl<'a> Unmap<'a> {
     ///
     ///     // Using the `map` and `unmap` features provided by the host:
     ///     # let mapper = lv2_urid::mapper::HashURIDMapper::new();
-    ///     # let map = lv2_urid::feature::Map::new(&mapper);
-    ///     # let unmap = lv2_urid::feature::Unmap::new(&mapper);
+    ///     # let map = lv2_urid::Map::new(&mapper);
+    ///     # let unmap = lv2_urid::Unmap::new(&mapper);
     ///     let urid: URID<MyUriBound> = map.map_type::<MyUriBound>().unwrap();
     ///     let uri: &Uri = unmap.unmap(urid).unwrap();
     ///     assert_eq!(MyUriBound::uri(), uri);

--- a/urid/src/lib.rs
+++ b/urid/src/lib.rs
@@ -7,11 +7,20 @@
 extern crate lv2_core as core;
 pub extern crate lv2_urid_sys as sys;
 
-pub mod feature;
 #[cfg(feature = "host")]
 pub mod mapper;
+
+mod feature;
 mod urid;
 
 pub use lv2_urid_derive::*;
 
+pub use feature::*;
 pub use urid::*;
+
+/// Prelude of `lv2_urid` for wildcard usage.
+pub mod prelude {
+    pub use crate::feature::{Map, Unmap};
+    pub use crate::{URIDBound, URIDCache, URID};
+    pub use lv2_urid_derive::*;
+}

--- a/urid/src/urid.rs
+++ b/urid/src/urid.rs
@@ -23,8 +23,8 @@ where
 /// # Usage example:
 ///
 ///     # #![cfg(feature = "host")]
-///     # use lv2_core::UriBound;
-///     # use lv2_urid::{URID, URIDCache};
+///     # use lv2_core::prelude::*;
+///     # use lv2_urid::prelude::*;
 ///     # use std::ffi::CStr;
 ///     // Defining all URI bounds.
 ///     struct MyTypeA;
@@ -47,8 +47,8 @@ where
 ///     }
 ///
 ///     # let mapper = lv2_urid::mapper::HashURIDMapper::new();
-///     # let map = lv2_urid::feature::Map::new(&mapper);
-///     # let unmap = lv2_urid::feature::Unmap::new(&mapper);
+///     # let map = lv2_urid::Map::new(&mapper);
+///     # let unmap = lv2_urid::Unmap::new(&mapper);
 ///     // Populating the cache, Using the `map` and `unmap` features provided by the host:
 ///     let cache = MyCache::from_map(&map).unwrap();
 ///

--- a/urid/tests/urid.rs
+++ b/urid/tests/urid.rs
@@ -3,10 +3,9 @@
 extern crate lv2_core as core;
 extern crate lv2_urid as urid;
 
-use core::UriBound;
-use urid::feature::*;
+use core::prelude::*;
 use urid::mapper::HashURIDMapper;
-use urid::*;
+use urid::prelude::*;
 
 struct MyTypeA;
 


### PR DESCRIPTION
While I was creating an integration test for atom, I saw potential to make `use` clauses simpler: You often have to `use` every single type you need on your own, which may be a bit frustrating when you've just started to work with rust-lv2. Therefore, I put all of the things you need to to `use` in preludes. I hope you're okay with that change!