### PR TITLE
Update bindgen to make builds (even!) lighter

### DIFF
--- a/core/derive/Cargo.toml
+++ b/core/derive/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["Janonard <jan.opdenhoevel@protonmail.com>", "Adrien Prokopowicz <adr
 proc-macro = true
 
 [dependencies]
-syn = "0.15.22"
-quote = "0.6.10"
+syn = "1.0.5"
+quote = "1.0.2"

--- a/core/sys/Cargo.toml
+++ b/core/sys/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Janonard <jan.opdenhoevel@protonmail.com>", "Adrien Prokopowicz <adrien.prokopowicz@gmail.com>"]
 
 [build-dependencies]
-bindgen = { version = "0.51.0", default-features = false }
+bindgen = { version = "0.51.1", default-features = false }

--- a/units/sys/Cargo.toml
+++ b/units/sys/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 
 [build-dependencies]
-bindgen = { version = "0.51.0", default-features = false }
+bindgen = { version = "0.51.1", default-features = false }

--- a/urid/derive/Cargo.toml
+++ b/urid/derive/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = "0.15.22"
-quote = "0.6.10"
+syn = "1.0.5"
+quote = "1.0.2"

--- a/urid/sys/Cargo.toml
+++ b/urid/sys/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 
 [build-dependencies]
-bindgen = { version = "0.51.0", default-features = false }
+bindgen = { version = "0.51.1", default-features = false }


### PR DESCRIPTION
This pulls in the latest update of bindgen, which contains some work I did in harryfei/which-rs#14 and rust-lang/rust-bindgen#1625 to further reduce the amount of indirect dependencies we have, and thus build times as well. :slightly_smiling_face: 

Basically, `bindgen` depends on the `which` crate, which had a mandatory dependency on `failure` which `bindgen` did not use at all. I removed the dependency in those two PRs, making all `bindgen` users free of having to pull `failure` as well as its own dependencies (most problematic being `backtrace`).

For us, this removes another 10 seconds of build times on my machine (from `1m28s` to `1m18s`). :slightly_smiling_face: 

This PR also updates the `syn` and `quote` crates to their `1.0` version, as I noticed `bindgen` depended on them as well, and we ended up having two different versions in the dependency tree.