### PR TITLE
Assuring that a LV2_Handle is a valid plugin pointer

### DIFF
--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -59,7 +59,7 @@ pub trait Plugin: UriBound + Sized + Send + Sync + 'static {
 /// Plugin wrapper which translated between the host and the plugin.
 ///
 /// The host interacts with the plugin via a C API, but the plugin is implemented with ideomatic, safe Rust. To bridge this gap, this wrapper is used to translate and abstract the communcation between the host and the plugin.
-/// 
+///
 /// This struct is `repr(C)` and has the plugin as it's first field. Therefore, a valid `*mut PluginInstance<T>` is also a valid `*mut T`.
 #[repr(C)]
 pub struct PluginInstance<T: Plugin> {

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -16,7 +16,7 @@ use sys::LV2_Handle;
 ///
 /// This trait and the structs that implement it are the centre of every plugin project, since it hosts the `run` method. This method is called by the host for every processing cycle.
 ///
-/// However, the host will not directly talk to the plugin. Instead, it will create and talk to the [`PluginInstance`](struct.PluginInstance.html), which dereferences raw pointers, does safety checks and then calls the corresponding plugin methods.
+/// However, the host will not directly talk to the plugin. Instead, it will create and talk to the [`PluginInstance`](struct.PluginInstance.html), which dereferences raw pointers, does safety checks and then calls the corresponding plugin methods. However, it guarantees that a valid `sys::LV2_Handle` is always a valid `*mut MyPlugin`, where `MyPlugin` is your plugin's name.
 pub trait Plugin: UriBound + Sized + Send + Sync + 'static {
     /// The type of the port collection.
     type Ports: PortCollection;
@@ -59,6 +59,9 @@ pub trait Plugin: UriBound + Sized + Send + Sync + 'static {
 /// Plugin wrapper which translated between the host and the plugin.
 ///
 /// The host interacts with the plugin via a C API, but the plugin is implemented with ideomatic, safe Rust. To bridge this gap, this wrapper is used to translate and abstract the communcation between the host and the plugin.
+/// 
+/// This struct is `repr(C)` and has the plugin as it's first field. Therefore, a valid `*mut PluginInstance<T>` is also a valid `*mut T`.
+#[repr(C)]
 pub struct PluginInstance<T: Plugin> {
     instance: T,
     connections: <T::Ports as PortCollection>::Cache,


### PR DESCRIPTION
This change fixes an unsoundness issue discovered by [YruamaLairba](https://github.com/YruamaLairba).

The problem is that the external methods of an extension need to cast the `LV2_Handle` they receive from the host to a Rust type in order to use them. Currently, the plugin instance the host deals with has the type `PluginInstance<P>`, where `P` is the type of the plugin. Therefore, an external extension method would need to cast the `LV2_Handle` to `*mut PluginInstance<P>`.

However, I didn't think about that when I wrote the `State` extension and casted the `LV2_Handle` to `*mut P`, which may be unsound since `PluginInstance` is `repr(Rust)` and therefore a pointer to an instance of this struct may or may not be a pointer to `P` too.

I could fix that in this instance, but others might forget this problem too. Therefore, I decided to make `PluginInstance<P>` `repr(C)` and assured that `P` is the first field of the struct. This means that a valid `*mut PluginInstance<P>` is also a valid `*mut P` and the entire source of the problem is solved.