### PR TITLE
Making features available for all methods

### DIFF
--- a/atom/tests/atom_integration.rs
+++ b/atom/tests/atom_integration.rs
@@ -36,15 +36,16 @@ unsafe impl UriBound for AtomPlugin {
 
 impl Plugin for AtomPlugin {
     type Ports = Ports;
-    type Features = Features<'static>;
+    type InitFeatures = Features<'static>;
+    type AudioFeatures = ();
 
-    fn new(_plugin_info: &PluginInfo, features: Features) -> Option<Self> {
+    fn new(_plugin_info: &PluginInfo, features: &mut Features) -> Option<Self> {
         Some(Self {
             urids: features.map.populate_collection()?,
         })
     }
 
-    fn run(&mut self, ports: &mut Ports) {
+    fn run(&mut self, ports: &mut Ports, _: &mut ()) {
         let sequence_reader = ports
             .input
             .read::<Sequence>(self.urids.atom.sequence, self.urids.units.beat)

--- a/core/derive/src/feature_collection_derive.rs
+++ b/core/derive/src/feature_collection_derive.rs
@@ -17,7 +17,7 @@ impl<'a> FeatureCollectionField<'a> {
 
     fn make_retrieval(&self) -> impl ::quote::ToTokens {
         let identifier = self.identifier;
-        quote! {#identifier: cache.retrieve_feature()?,}
+        quote! {#identifier: cache.retrieve_feature(class)?,}
     }
 }
 
@@ -58,7 +58,8 @@ impl<'a> FeatureCollectionStruct<'a> {
         (quote! {
             impl#generics FeatureCollection<#lifetime> for #struct_name#generics {
                 fn from_cache(
-                    cache: &mut FeatureCache<#lifetime>
+                    cache: &mut FeatureCache<#lifetime>,
+                    class: ThreadingClass,
                 ) -> Result<Self, MissingFeatureError> {
                     Ok(Self {
                         #(#retrievals)*

--- a/core/src/extension.rs
+++ b/core/src/extension.rs
@@ -74,13 +74,14 @@
 //!
 //! impl Plugin for MyPlugin {
 //!     type Ports = ();
-//!     type Features = ();
+//!     type InitFeatures = ();
+//!     type AudioFeatures = ();
 //!
-//!     fn new(_: &PluginInfo, _: ()) -> Option<Self> {
+//!     fn new(_: &PluginInfo, _: &mut ()) -> Option<Self> {
 //!         Some(Self { internal: 0 })
 //!     }
 //!
-//!     fn run(&mut self, _: &mut ()) {
+//!     fn run(&mut self, _: &mut (), _: &mut ()) {
 //!         self.internal += 1;
 //!     }
 //!
@@ -109,7 +110,7 @@
 //! let sample_rate = 44100.0;
 //! let plugin_info = PluginInfo::new(plugin_uri, bundle_path, sample_rate);
 //!
-//! let mut plugin = MyPlugin::new(&plugin_info, ()).unwrap();
+//! let mut plugin = MyPlugin::new(&plugin_info, &mut ()).unwrap();
 //!
 //! let extension = MyPlugin::extension_data(MyExtensionDescriptor::<MyPlugin>::uri())
 //!     .and_then(|interface| interface.downcast_ref::<MyExtensionInterface>())

--- a/core/src/feature/cache.rs
+++ b/core/src/feature/cache.rs
@@ -1,3 +1,8 @@
+use crate::feature::*;
+use std::collections::{hash_map, HashMap};
+use std::ffi::{c_void, CStr};
+use std::iter::Map;
+
 /// Cache for host features, used in the feature discovery stage.
 ///
 /// At initialization time, a raw LV2 plugin receives a null-terminated array containing all requested host features. Obviously, this is not suited for safe Rust code and therefore, it needs an abstraction layer.
@@ -43,19 +48,15 @@ impl<'a> FeatureCache<'a> {
     /// If feature is not found, this method will return `None`. Since the resulting feature object may have writing access to the raw data, it will be removed from the cache to avoid the existence of two feature objects with writing access.
     pub fn retrieve_feature<F: Feature, T: FromResolvedFeature<F>>(
         &mut self,
+        class: ThreadingClass,
     ) -> Result<T, MissingFeatureError> {
         T::from_resolved_feature(
             self.internal
                 .remove(F::uri())
-                .and_then(|ptr| unsafe { F::from_feature_ptr(ptr) }),
+                .and_then(|ptr| unsafe { F::from_feature_ptr(ptr, class) }),
         )
     }
 }
-
-use crate::feature::{Feature, FeatureCollection, FeatureDescriptor, MissingFeatureError};
-use std::collections::{hash_map, HashMap};
-use std::ffi::{c_void, CStr};
-use std::iter::Map;
 
 type HashMapIterator<'a> = hash_map::IntoIter<&'a CStr, *const c_void>;
 type DescriptorBuildFn<'a> = fn((&'a CStr, *const c_void)) -> FeatureDescriptor<'a>;
@@ -74,7 +75,10 @@ impl<'a> std::iter::IntoIterator for FeatureCache<'a> {
 }
 
 impl<'a> FeatureCollection<'a> for FeatureCache<'a> {
-    fn from_cache(cache: &mut FeatureCache<'a>) -> Result<Self, MissingFeatureError> {
+    fn from_cache(
+        cache: &mut FeatureCache<'a>,
+        _: ThreadingClass,
+    ) -> Result<Self, MissingFeatureError> {
         Ok(FeatureCache {
             internal: cache.internal.clone(),
         })

--- a/core/src/feature/cache.rs
+++ b/core/src/feature/cache.rs
@@ -45,7 +45,9 @@ impl<'a> FeatureCache<'a> {
 
     /// Try to retrieve a feature.
     ///
-    /// If feature is not found, this method will return `None`. Since the resulting feature object may have writing access to the raw data, it will be removed from the cache to avoid the existence of two feature objects with writing access.
+    /// If the feature is not found, this method will return `None`. Since the resulting feature object may have mutable access to the raw data, it will be removed from the cache to avoid aliasing.
+    ///
+    /// You also have to provide the threading class of the feature you want to retrieve.
     pub fn retrieve_feature<F: Feature, T: FromResolvedFeature<F>>(
         &mut self,
         class: ThreadingClass,

--- a/core/src/feature/core_features.rs
+++ b/core/src/feature/core_features.rs
@@ -2,7 +2,7 @@
 //!
 //! This module is for internal organization only and is not meant to be exposed.
 
-use crate::feature::Feature;
+use crate::feature::*;
 use crate::UriBound;
 use std::ffi::c_void;
 
@@ -14,7 +14,7 @@ unsafe impl UriBound for HardRTCapable {
 }
 
 unsafe impl Feature for HardRTCapable {
-    unsafe fn from_feature_ptr(_feature: *const c_void) -> Option<Self> {
+    unsafe fn from_feature_ptr(_feature: *const c_void, _: ThreadingClass) -> Option<Self> {
         Some(Self)
     }
 }
@@ -29,7 +29,7 @@ unsafe impl UriBound for InPlaceBroken {
 }
 
 unsafe impl<'a> Feature for InPlaceBroken {
-    unsafe fn from_feature_ptr(_feature: *const c_void) -> Option<Self> {
+    unsafe fn from_feature_ptr(_feature: *const c_void, _: ThreadingClass) -> Option<Self> {
         Some(Self)
     }
 }
@@ -42,7 +42,7 @@ unsafe impl UriBound for IsLive {
 }
 
 unsafe impl<'a> Feature for IsLive {
-    unsafe fn from_feature_ptr(_feature: *const c_void) -> Option<Self> {
+    unsafe fn from_feature_ptr(_feature: *const c_void, _: ThreadingClass) -> Option<Self> {
         Some(Self)
     }
 }

--- a/core/src/feature/core_features.rs
+++ b/core/src/feature/core_features.rs
@@ -28,7 +28,7 @@ unsafe impl UriBound for InPlaceBroken {
     const URI: &'static [u8] = ::lv2_sys::LV2_CORE__inPlaceBroken;
 }
 
-unsafe impl<'a> Feature for InPlaceBroken {
+unsafe impl Feature for InPlaceBroken {
     unsafe fn from_feature_ptr(_feature: *const c_void, _: ThreadingClass) -> Option<Self> {
         Some(Self)
     }
@@ -41,7 +41,7 @@ unsafe impl UriBound for IsLive {
     const URI: &'static [u8] = ::lv2_sys::LV2_CORE__isLive;
 }
 
-unsafe impl<'a> Feature for IsLive {
+unsafe impl Feature for IsLive {
     unsafe fn from_feature_ptr(_feature: *const c_void, _: ThreadingClass) -> Option<Self> {
         Some(Self)
     }

--- a/core/src/feature/descriptor.rs
+++ b/core/src/feature/descriptor.rs
@@ -1,6 +1,6 @@
 //! This module is for internal organization only and is not meant to be exposed.
 
-use crate::feature::Feature;
+use crate::feature::*;
 use std::ffi::{c_void, CStr};
 
 /// Descriptor of a single host feature.
@@ -33,7 +33,7 @@ impl<'a> FeatureDescriptor<'a> {
     /// If this object describes the requested feature, it will be created from the raw data. This operation consumes the descriptor since it would be possible to have multiple features instances otherwise.
     ///
     /// If the feature construction fails, the descriptor will be returned again.
-    pub fn into_feature<T: Feature>(self) -> Result<T, Self> {
-        unsafe { T::from_feature_ptr(self.data) }.ok_or(self)
+    pub fn into_feature<T: Feature>(self, class: ThreadingClass) -> Result<T, Self> {
+        unsafe { T::from_feature_ptr(self.data, class) }.ok_or(self)
     }
 }

--- a/core/src/feature/descriptor.rs
+++ b/core/src/feature/descriptor.rs
@@ -30,7 +30,7 @@ impl<'a> FeatureDescriptor<'a> {
 
     /// Try to return a feature struct instance from the internal data.
     ///
-    /// If this object describes the requested feature, it will be created from the raw data. This operation consumes the descriptor since it would be possible to have multiple features instances otherwise.
+    /// If this object describes the requested feature, it will be created from the raw data. This operation consumes the descriptor since it would be possible to have multiple features instances otherwise. You also have to provide the threading class of the feature.
     ///
     /// If the feature construction fails, the descriptor will be returned again.
     pub fn into_feature<T: Feature>(self, class: ThreadingClass) -> Result<T, Self> {

--- a/core/src/feature/mod.rs
+++ b/core/src/feature/mod.rs
@@ -11,6 +11,9 @@ pub use descriptor::FeatureDescriptor;
 
 use std::ffi::c_void;
 
+/// All threading contexts of LV2 interface methods.
+///
+/// The [core LV2 specifications](https://lv2plug.in/ns/lv2core/lv2core.html) declare three threading classes: "Discovery", where plugins are discovered by the host, "Instantiation", where plugins are instantiated and (de-)activated, and "Audio", where the actual audio processing happens.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ThreadingClass {
     Discovery,
@@ -21,11 +24,13 @@ pub enum ThreadingClass {
 
 /// Trait to generalize the feature detection system.
 ///
-/// A host that only implements the core LV2 specification does not have much functionality. Therefore, hosts can provide extra functionalities, called "Features", a plugin can use to become more useful.
+/// A host that only implements the core LV2 specification does not have much functionality. Instead, hosts can provide extra functionalities, called "host features" or short "features", which a make plugins more useful.
 ///
 /// A native plugin written in C would discover a host's features by iterating through an array of URIs and pointers. When it finds the URI of the feature it is looking for, it casts the pointer to the type of the feature interface and uses the information from the interface.
 ///
 /// In Rust, most of this behaviour is done internally and instead of simply casting a pointer, a safe feature descriptor, which implements this trait, is constructed using the [`from_raw_data`](#tymethod.from_raw_data) method.
+///
+/// Some host features may only be used in certain threading classes. This is guarded by rust-lv2 by passing the threading class in which the plugin will be used to the feature, which then may take different actions.
 pub unsafe trait Feature: UriBound + Sized {
     /// Create an instance of the featurer.
     ///
@@ -34,6 +39,10 @@ pub unsafe trait Feature: UriBound + Sized {
     /// # Implementing
     ///
     /// If nescessary, you should dereference it and store the reference inside the feature struct in order to use it.
+    ///
+    /// You have to document in which threading classes your feature can be used and should panic if the threading class is not supported. When this happens when the plugin programmer has added your feature to the wrong feature collection, which is considered a programming error and therefore justifies the panic. If you don't panic in this case, the error is handled silently, which may make debugging harder.
+    ///
+    /// You should always allow the [`Other`](enum.ThreadingClass.html#variant.Other) threading class in order to restrict your feature from use cases you might not know.
     ///
     /// # Safety
     ///
@@ -75,7 +84,7 @@ impl std::fmt::Display for MissingFeatureError {
 ///         hardrt: Option<HardRTCapable>,
 ///     }
 pub trait FeatureCollection<'a>: Sized + 'a {
-    /// Populate a collection with features from the cache.
+    /// Populate a collection with features from the cache for the given threading class.
     fn from_cache(
         cache: &mut FeatureCache<'a>,
         class: ThreadingClass,

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -1,5 +1,5 @@
 //! Prelude for wildcard use, containing many important types.
-pub use crate::feature::{FeatureCache, FeatureCollection, MissingFeatureError};
+pub use crate::feature::{FeatureCache, FeatureCollection, MissingFeatureError, ThreadingClass};
 pub use crate::match_extensions;
 pub use crate::plugin::{lv2_descriptors, Plugin, PluginInfo, PortCollection};
 pub use crate::port::*;

--- a/core/tests/amp.rs
+++ b/core/tests/amp.rs
@@ -27,10 +27,11 @@ struct Features {
 
 impl Plugin for Amp {
     type Ports = AmpPorts;
-    type Features = Features;
+    type InitFeatures = Features;
+    type AudioFeatures = ();
 
     #[inline]
-    fn new(plugin_info: &PluginInfo, features: Features) -> Option<Self> {
+    fn new(plugin_info: &PluginInfo, features: &mut Features) -> Option<Self> {
         // Verifying the plugin info.
         assert_eq!(
             plugin_info.plugin_uri().to_str().unwrap(),
@@ -48,13 +49,13 @@ impl Plugin for Amp {
         Some(Amp { activated: false })
     }
 
-    fn activate(&mut self) {
+    fn activate(&mut self, _: &mut Features) {
         assert!(!self.activated);
         self.activated = true;
     }
 
     #[inline]
-    fn run(&mut self, ports: &mut AmpPorts) {
+    fn run(&mut self, ports: &mut AmpPorts, _: &mut ()) {
         assert!(self.activated);
 
         let coef = *(ports.gain);
@@ -67,7 +68,7 @@ impl Plugin for Amp {
         }
     }
 
-    fn deactivate(&mut self) {
+    fn deactivate(&mut self, _: &mut Features) {
         assert!(self.activated);
         self.activated = false;
     }

--- a/state/src/interface.rs
+++ b/state/src/interface.rs
@@ -67,7 +67,9 @@ impl<P: State> StateDescriptor<P> {
         let store = StoreHandle::new(store, handle);
 
         let mut feature_container = core::feature::FeatureCache::from_raw(features);
-        let features = if let Ok(features) = P::StateFeatures::from_cache(&mut feature_container) {
+        let features = if let Ok(features) =
+            P::StateFeatures::from_cache(&mut feature_container, ThreadingClass::Other)
+        {
             features
         } else {
             return sys::LV2_State_Status_LV2_STATE_ERR_NO_FEATURE;
@@ -103,7 +105,9 @@ impl<P: State> StateDescriptor<P> {
         let store = RetrieveHandle::new(retrieve, handle);
 
         let mut feature_container = core::feature::FeatureCache::from_raw(features);
-        let features = if let Ok(features) = P::StateFeatures::from_cache(&mut feature_container) {
+        let features = if let Ok(features) =
+            P::StateFeatures::from_cache(&mut feature_container, ThreadingClass::Other)
+        {
             features
         } else {
             return sys::LV2_State_Status_LV2_STATE_ERR_NO_FEATURE;
@@ -135,16 +139,17 @@ mod tests {
     }
 
     impl Plugin for Stateful {
-        type Features = ();
+        type InitFeatures = ();
+        type AudioFeatures = ();
         type Ports = ();
 
         #[cfg_attr(tarpaulin, skip)]
-        fn new(_: &PluginInfo, _: ()) -> Option<Self> {
+        fn new(_: &PluginInfo, _: &mut ()) -> Option<Self> {
             Some(Self)
         }
 
         #[cfg_attr(tarpaulin, skip)]
-        fn run(&mut self, _: &mut ()) {}
+        fn run(&mut self, _: &mut (), _: &mut ()) {}
     }
 
     #[derive(FeatureCollection)]

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -44,16 +44,17 @@
 //!
 //! impl Plugin for Stateful {
 //!     type Ports = ();
-//!     type Features = Features<'static>;
+//!     type InitFeatures = Features<'static>;
+//!     type AudioFeatures = ();
 //!
-//!     fn new(_: &PluginInfo, features: Features<'static>) -> Option<Self> {
+//!     fn new(_: &PluginInfo, features: &mut Features<'static>) -> Option<Self> {
 //!         Some(Stateful {
 //!             internal: 42.0,
 //!             urids: features.map.populate_collection()?,
 //!         })
 //!     }
 //!
-//!     fn run(&mut self, _: &mut ()) {
+//!     fn run(&mut self, _: &mut (), _: &mut ()) {
 //!         // Set the float to a different value than the previous one.
 //!         self.internal += 1.0;
 //!     }

--- a/state/tests/integration.rs
+++ b/state/tests/integration.rs
@@ -25,9 +25,10 @@ unsafe impl UriBound for Stateful {
 
 impl Plugin for Stateful {
     type Ports = ();
-    type Features = Features<'static>;
+    type InitFeatures = Features<'static>;
+    type AudioFeatures = ();
 
-    fn new(_plugin_info: &PluginInfo, features: Features<'static>) -> Option<Self> {
+    fn new(_plugin_info: &PluginInfo, features: &mut Features<'static>) -> Option<Self> {
         Some(Stateful {
             internal: 42.0,
             audio: Vec::new(),
@@ -35,7 +36,7 @@ impl Plugin for Stateful {
         })
     }
 
-    fn run(&mut self, _: &mut ()) {
+    fn run(&mut self, _: &mut (), _: &mut ()) {
         self.internal = 17.0;
         self.audio.extend((0..32).map(|f| f as f32));
     }
@@ -88,7 +89,7 @@ fn create_plugin(mapper: Pin<&mut HashURIDMapper>) -> Stateful {
         // Constructing the plugin.
         Stateful::new(
             &PluginInfo::new(Stateful::uri(), Path::new("./"), 44100.0),
-            Features { map: map },
+            &mut Features { map: map },
         )
         .unwrap()
     };
@@ -117,7 +118,7 @@ fn test_save_n_restore() {
 
     let mut first_plugin = create_plugin(mapper.as_mut());
 
-    first_plugin.run(&mut ());
+    first_plugin.run(&mut (), &mut ());
 
     assert_eq!(17.0, first_plugin.internal);
     assert_eq!(32, first_plugin.audio.len());

--- a/urid/src/feature.rs
+++ b/urid/src/feature.rs
@@ -23,7 +23,7 @@ unsafe impl<'a> Feature for Map<'a> {
                 .as_ref()
                 .map(|internal| Self { internal })
         } else {
-            None
+            panic!("The URID mapping feature isn't allowed in the audio threading class");
         }
     }
 }
@@ -122,7 +122,7 @@ unsafe impl<'a> Feature for Unmap<'a> {
                 .as_ref()
                 .map(|internal| Self { internal })
         } else {
-            None
+            panic!("The URID unmapping feature isn't allowed in the audio threading class");
         }
     }
 }

--- a/urid/src/feature.rs
+++ b/urid/src/feature.rs
@@ -2,8 +2,7 @@
 
 use crate::{URIDCollection, URID};
 use core::feature::Feature;
-use core::Uri;
-use core::UriBound;
+use core::prelude::*;
 use std::ffi::c_void;
 use std::os::raw::c_char;
 
@@ -18,10 +17,14 @@ unsafe impl<'a> UriBound for Map<'a> {
 }
 
 unsafe impl<'a> Feature for Map<'a> {
-    unsafe fn from_feature_ptr(feature: *const c_void) -> Option<Self> {
-        (feature as *const sys::LV2_URID_Map)
-            .as_ref()
-            .map(|internal| Self { internal })
+    unsafe fn from_feature_ptr(feature: *const c_void, class: ThreadingClass) -> Option<Self> {
+        if class != ThreadingClass::Audio {
+            (feature as *const sys::LV2_URID_Map)
+                .as_ref()
+                .map(|internal| Self { internal })
+        } else {
+            None
+        }
     }
 }
 
@@ -113,10 +116,14 @@ unsafe impl<'a> UriBound for Unmap<'a> {
 }
 
 unsafe impl<'a> Feature for Unmap<'a> {
-    unsafe fn from_feature_ptr(feature: *const c_void) -> Option<Self> {
-        (feature as *const sys::LV2_URID_Unmap)
-            .as_ref()
-            .map(|internal| Self { internal })
+    unsafe fn from_feature_ptr(feature: *const c_void, class: ThreadingClass) -> Option<Self> {
+        if class != ThreadingClass::Audio {
+            (feature as *const sys::LV2_URID_Unmap)
+                .as_ref()
+                .map(|internal| Self { internal })
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
These changes allow plugin methods to access host features and also allows features to limit themselves to specific threading classes.

According to the [core LV2 specifications](https://lv2plug.in/ns/lv2core/lv2core.html), there are three threading classes: "Discovery", "Instantiation", and "Audio". Features are discovered in the "Instantiation" class and therefore, only "Instantiation" and "Audio" methods are able to access host features.

Since we also want to limit certain features to certain threading classes, or disallow them in others, I've split the `Features` type definition in the `Plugin` trait to `InitFeatures` and `AudioFeatures`. During instantiation, these feature collections are created and stored in the `PluginInstance`. Then, all methods get access to their respective collections via a mutable reference. Extensions that add new methods in these two threading classes can also retrieve mutable references to these collections and pass them to their new methods.

This is only a draft yet and I didn't update the documentation too. This needs to be done before this PR can be pulled.