### PR TITLE
Adding a `uri` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ struct Ports {
 }
 
 // The plugin struct. In this case, we don't need any data and therefore, this struct is empty.
+#[uri_bound("urn:rust-lv2-book:eg-amp-rs")]
 struct Amp;
 
 // LV2 uses URIs to identify types. This association is expressed via the `UriBound` trait, which
@@ -60,9 +61,8 @@ struct Amp;
 //
 // This trait is unsafe to implement since you **need** to include the \0 character at the end of
 // the string.
-unsafe impl UriBound for Amp {
-    const URI: &'static [u8] = b"urn:rust-lv2-book:eg-amp-rs\0";
-}
+// TODO: Move the doc to an appropriate place.
+
 
 // The implementation of the `Plugin` trait, which turns `Amp` into a plugin.
 impl Plugin for Amp {

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ struct Ports {
 }
 
 // The plugin struct. In this case, we don't need any data and therefore, this struct is empty.
-#[uri_bound("urn:rust-lv2-book:eg-amp-rs")]
+#[uri("urn:rust-lv2-book:eg-amp-rs")]
 struct Amp;
 
 // LV2 uses URIs to identify types. This association is expressed via the `UriBound` trait, which

--- a/atom/src/object.rs
+++ b/atom/src/object.rs
@@ -8,10 +8,10 @@
 //! use lv2_atom::prelude::*;
 //! use urid::*;
 //!
-//! #[uri_bound("urn:object-class")]
+//! #[uri("urn:object-class")]
 //! struct ObjectClass;
 //!
-//! #[uri_bound("urn:property-a")]
+//! #[uri("urn:property-a")]
 //! struct PropertyA;
 //!
 //! #[derive(PortCollection)]

--- a/atom/src/object.rs
+++ b/atom/src/object.rs
@@ -8,15 +8,11 @@
 //! use lv2_atom::prelude::*;
 //! use urid::*;
 //!
+//! #[uri_bound("urn:object-class")]
 //! struct ObjectClass;
-//! unsafe impl UriBound for ObjectClass {
-//!     const URI: &'static [u8] = b"urn:object-class\0";
-//! }
 //!
+//! #[uri_bound("urn:property-a")]
 //! struct PropertyA;
-//! unsafe impl UriBound for PropertyA {
-//!     const URI: &'static [u8] = b"urn:property-a\0";
-//! }
 //!
 //! #[derive(PortCollection)]
 //! struct MyPorts {

--- a/atom/tests/atom_integration.rs
+++ b/atom/tests/atom_integration.rs
@@ -26,7 +26,7 @@ struct URIDs {
     units: UnitURIDCollection,
 }
 
-#[uri_bound("urn:rust-lv2:atom-plugin")]
+#[uri("urn:rust-lv2:atom-plugin")]
 struct AtomPlugin {
     urids: URIDs,
 }

--- a/atom/tests/atom_integration.rs
+++ b/atom/tests/atom_integration.rs
@@ -26,12 +26,9 @@ struct URIDs {
     units: UnitURIDCollection,
 }
 
+#[uri_bound("urn:rust-lv2:atom-plugin")]
 struct AtomPlugin {
     urids: URIDs,
-}
-
-unsafe impl UriBound for AtomPlugin {
-    const URI: &'static [u8] = b"urn:rust-lv2:atom-plugin\0";
 }
 
 impl Plugin for AtomPlugin {

--- a/core/README.md
+++ b/core/README.md
@@ -23,6 +23,7 @@ struct Ports {
 }
 
 // The plugin struct. In this case, we don't need any data and therefore, this struct is empty.
+#[uri_bound("rn:rust-lv2-book:eg-amp-rs")]
 struct Amp;
 
 // LV2 uses URIs to identify types. This association is expressed via the `UriBound` trait, which
@@ -30,9 +31,6 @@ struct Amp;
 //
 // This trait is unsafe to implement since you **need** to include the \0 character at the end of
 // the string.
-unsafe impl UriBound for Amp {
-    const URI: &'static [u8] = b"urn:rust-lv2-book:eg-amp-rs\0";
-}
 
 // The implementation of the `Plugin` trait, which turns `Amp` into a plugin.
 impl Plugin for Amp {

--- a/core/README.md
+++ b/core/README.md
@@ -23,7 +23,7 @@ struct Ports {
 }
 
 // The plugin struct. In this case, we don't need any data and therefore, this struct is empty.
-#[uri_bound("rn:rust-lv2-book:eg-amp-rs")]
+#[uri("rn:rust-lv2-book:eg-amp-rs")]
 struct Amp;
 
 // LV2 uses URIs to identify types. This association is expressed via the `UriBound` trait, which

--- a/core/src/extension.rs
+++ b/core/src/extension.rs
@@ -65,7 +65,7 @@
 //! // ##########
 //!
 //! /// This plugin actually isn't a plugin, it only has a counter.
-//! #[uri_bound("urn:my-project:my-plugin")]
+//! #[uri("urn:my-project:my-plugin")]
 //! pub struct MyPlugin {
 //!     internal: u32,
 //! }

--- a/core/src/extension.rs
+++ b/core/src/extension.rs
@@ -65,12 +65,9 @@
 //! // ##########
 //!
 //! /// This plugin actually isn't a plugin, it only has a counter.
+//! #[uri_bound("urn:my-project:my-plugin")]
 //! pub struct MyPlugin {
 //!     internal: u32,
-//! }
-//!
-//! unsafe impl UriBound for MyPlugin {
-//!     const URI: &'static [u8] = b"urn:my-project:my-plugin\0";
 //! }
 //!
 //! impl Plugin for MyPlugin {

--- a/core/tests/amp.rs
+++ b/core/tests/amp.rs
@@ -5,7 +5,7 @@ use std::ops::Drop;
 use std::os::raw::c_char;
 use urid::*;
 
-#[uri_bound("http://lv2plug.in/plugins.rs/example_amp")]
+#[uri("http://lv2plug.in/plugins.rs/example_amp")]
 struct Amp {
     activated: bool,
 }

--- a/core/tests/amp.rs
+++ b/core/tests/amp.rs
@@ -5,12 +5,9 @@ use std::ops::Drop;
 use std::os::raw::c_char;
 use urid::*;
 
+#[uri_bound("http://lv2plug.in/plugins.rs/example_amp")]
 struct Amp {
     activated: bool,
-}
-
-unsafe impl UriBound for Amp {
-    const URI: &'static [u8] = b"http://lv2plug.in/plugins.rs/example_amp\0";
 }
 
 #[derive(PortCollection)]

--- a/state/src/interface.rs
+++ b/state/src/interface.rs
@@ -138,11 +138,8 @@ mod tests {
     use lv2_urid::*;
     use urid::*;
 
+    #[uri_bound("urn:stateful")]
     struct Stateful;
-
-    unsafe impl UriBound for Stateful {
-        const URI: &'static [u8] = b"urn:null\0";
-    }
 
     impl Plugin for Stateful {
         type InitFeatures = ();

--- a/state/src/interface.rs
+++ b/state/src/interface.rs
@@ -138,7 +138,7 @@ mod tests {
     use lv2_urid::*;
     use urid::*;
 
-    #[uri_bound("urn:stateful")]
+    #[uri("urn:stateful")]
     struct Stateful;
 
     impl Plugin for Stateful {

--- a/urid/derive/Cargo.toml
+++ b/urid/derive/Cargo.toml
@@ -22,3 +22,6 @@ quote = "1.0.2"
 proc-macro2 = "1.0.9"
 regex = "1.3.5"
 lazy_static = "1.4.0"
+
+[dev-dependencies]
+urid = "0.1.0"

--- a/urid/derive/Cargo.toml
+++ b/urid/derive/Cargo.toml
@@ -17,5 +17,8 @@ maintenance = { status = "passively-maintained" }
 proc-macro = true
 
 [dependencies]
-syn = "1.0.5"
+syn = {version = "1.0.5", features = ["full"]}
 quote = "1.0.2"
+proc-macro2 = "1.0.9"
+regex = "1.3.5"
+lazy_static = "1.4.0"

--- a/urid/derive/src/lib.rs
+++ b/urid/derive/src/lib.rs
@@ -6,6 +6,7 @@ extern crate syn;
 #[macro_use]
 extern crate quote;
 
+mod uri_bound;
 mod urid_collection_derive;
 
 use proc_macro::TokenStream;
@@ -13,4 +14,9 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(URIDCollection)]
 pub fn urid_collection_derive(input: TokenStream) -> TokenStream {
     urid_collection_derive::urid_collection_derive_impl(input)
+}
+
+#[proc_macro_attribute]
+pub fn uri_bound(attr: TokenStream, item: TokenStream) -> TokenStream {
+    uri_bound::impl_uri_bound(attr, item)
 }

--- a/urid/derive/src/lib.rs
+++ b/urid/derive/src/lib.rs
@@ -1,11 +1,6 @@
 //! Procedural macros for `urid`.
 #![recursion_limit = "128"]
 
-extern crate proc_macro;
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
 mod uri_bound;
 mod urid_collection_derive;
 
@@ -17,6 +12,6 @@ pub fn urid_collection_derive(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn uri_bound(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn uri(attr: TokenStream, item: TokenStream) -> TokenStream {
     uri_bound::impl_uri_bound(attr, item)
 }

--- a/urid/derive/src/uri_bound.rs
+++ b/urid/derive/src/uri_bound.rs
@@ -1,0 +1,50 @@
+use lazy_static::lazy_static;
+use proc_macro::TokenStream;
+use proc_macro2::Literal;
+use regex::Regex;
+use syn::{Ident, ItemStruct, ItemUnion, ItemEnum, ItemType, parse};
+
+fn get_type_name(item: &TokenStream) -> Ident {
+    if let Ok(struct_definition) = parse::<ItemStruct>(item.clone()) {
+        struct_definition.ident
+    } else if let Ok(enum_definition) = parse::<ItemEnum>(item.clone()) {
+        enum_definition.ident
+    } else if let Ok(type_definition) = parse::<ItemType>(item.clone()) {
+        type_definition.ident
+    } else if let Ok(union_definition) = parse::<ItemUnion>(item.clone()) {
+        union_definition.ident
+    } else {
+        panic!();
+    }
+}
+
+fn get_uri(attr: TokenStream) -> Vec<u8> {
+    lazy_static! {
+        static ref GET_STRING_RE: Regex = Regex::new(r#""(.*)""#).unwrap();
+    }
+
+    let uri = attr.to_string();
+    let mut uri = GET_STRING_RE
+        .captures(uri.as_str())
+        .unwrap()
+        .get(1)
+        .unwrap()
+        .as_str()
+        .as_bytes()
+        .to_vec();
+    uri.push(0);
+    uri
+}
+
+pub fn impl_uri_bound(attr: TokenStream, mut item: TokenStream) -> TokenStream {
+    let type_name = get_type_name(&item);
+    let uri = Literal::byte_string(get_uri(attr).as_ref());
+    let implementation: TokenStream = quote! {
+        unsafe impl ::urid::UriBound for #type_name {
+            const URI: &'static [u8] = #uri;
+        }
+    }
+    .into();
+    item.extend(implementation);
+    item
+}

--- a/urid/derive/src/uri_bound.rs
+++ b/urid/derive/src/uri_bound.rs
@@ -10,7 +10,7 @@ use syn::{parse, Ident, Item};
 /// This function also checks that the item has no generics, since this macro isn't smart enough to
 /// implement `UriBound` for all arguments of the generic type.
 fn get_type_ident(item: TokenStream) -> Ident {
-    const PARSING_ERROR: &'static str = "Only structs, enums, types, and unions may have a URI";
+    const PARSING_ERROR: &str = "Only structs, enums, types, and unions may have a URI";
 
     let (ident, generics) = match parse::<Item>(item).expect(PARSING_ERROR) {
         Item::Enum(definition) => (definition.ident, definition.generics),
@@ -20,7 +20,7 @@ fn get_type_ident(item: TokenStream) -> Ident {
         _ => panic!(PARSING_ERROR),
     };
 
-    if generics.params.len() > 0 {
+    if !generics.params.is_empty() {
         panic!("The uri attribute does not support generic types");
     }
     ident
@@ -34,7 +34,7 @@ fn get_uri(attr: TokenStream) -> Literal {
         static ref GET_STRING_RE: Regex = Regex::new(r#"^"(.*)"$"#).unwrap();
     }
 
-    const PARSING_ERROR: &'static str = "A URI has to be a string literal";
+    const PARSING_ERROR: &str = "A URI has to be a string literal";
 
     if parse::<Literal>(attr.clone()).is_err() {
         panic!(PARSING_ERROR);

--- a/urid/derive/src/urid_collection_derive.rs
+++ b/urid/derive/src/urid_collection_derive.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
-use syn::DeriveInput;
-use syn::{parse_macro_input, Data, DataStruct};
+use quote::quote;
+use syn::{parse_macro_input, Data, DataStruct, DeriveInput};
 
 pub fn urid_collection_derive_impl(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);

--- a/urid/derive/tests/uri_bound.rs
+++ b/urid/derive/tests/uri_bound.rs
@@ -1,0 +1,41 @@
+use urid::*;
+
+#[uri("urn:my-struct")]
+pub struct MyStruct {
+    _a: i32,
+}
+
+#[uri("urn:my-enum")]
+pub enum MyEnum {
+    _A,
+    _B,
+}
+
+#[uri("urn:my-union")]
+pub union MyUnion {
+    _a: i32,
+    _b: f32,
+}
+
+pub struct MyGeneric<T> {
+    _t: T,
+}
+
+#[uri("urn:my-type")]
+pub type MyType = MyGeneric<i32>;
+
+fn test_type<T: UriBound>(expected_uri: &str) {
+    // Test for the null terminator.
+    assert_eq!(0, T::URI[T::URI.len() - 1]);
+
+    // Test for string equality.
+    assert_eq!(expected_uri, T::uri().to_str().unwrap());
+}
+
+#[test]
+fn test_bounds() {
+    test_type::<MyStruct>("urn:my-struct");
+    test_type::<MyEnum>("urn:my-enum");
+    test_type::<MyUnion>("urn:my-union");
+    test_type::<MyType>("urn:my-type");
+}

--- a/urid/lv2-urid/tests/urid.rs
+++ b/urid/lv2-urid/tests/urid.rs
@@ -2,17 +2,11 @@ use lv2_urid::*;
 use std::pin::Pin;
 use urid::*;
 
+#[uri_bound("urn:my-type-a")]
 struct MyTypeA;
 
-unsafe impl UriBound for MyTypeA {
-    const URI: &'static [u8] = b"urn:my-type-a\0";
-}
-
+#[uri_bound("urn:my-type-b")]
 struct MyTypeB;
-
-unsafe impl UriBound for MyTypeB {
-    const URI: &'static [u8] = b"urn:my-type-b\0";
-}
 
 #[test]
 fn test_map() {

--- a/urid/lv2-urid/tests/urid.rs
+++ b/urid/lv2-urid/tests/urid.rs
@@ -2,10 +2,10 @@ use lv2_urid::*;
 use std::pin::Pin;
 use urid::*;
 
-#[uri_bound("urn:my-type-a")]
+#[uri("urn:my-type-a")]
 struct MyTypeA;
 
-#[uri_bound("urn:my-type-b")]
+#[uri("urn:my-type-b")]
 struct MyTypeB;
 
 #[test]

--- a/urid/src/lib.rs
+++ b/urid/src/lib.rs
@@ -7,6 +7,46 @@
 //! This library also supports connecting URIDs to their `UriBound` via a generics argument. This can be used, for example, to request the URID of a certain bound as a parameter of a function. If someone would try to call this function with the wrong URID, the compiler will raise an error before the code is even compiled.
 //!
 //! This may seem a bit minor to you now, but the audio plugin framework [rust-lv2](https://github.com/RustAudio/rust-lv2) heavily relies on this crate for fast, portable and dynamic data identification and exchange.
+//!
+//! # Example
+//!
+//! ```
+//! use urid::*;
+//!
+//! // Some types with URIs. The attribute implements `UriBound` with the given URI.
+//! #[uri("urn:urid-example:my-struct-a")]
+//! struct MyStructA;
+//!
+//! #[uri("urn:urid-example:my-struct-b")]
+//! struct MyStructB;
+//!
+//! // A collection of URIDs that can be created by a mapper with one method call.
+//! #[derive(URIDCollection)]
+//! struct MyURIDCollection {
+//!     my_struct_a: URID<MyStructA>,
+//!     my_struct_b: URID<MyStructB>,
+//! }
+//!
+//! // A function that checks whether the unmapper behaves correctly.
+//! // Due to the type argument, it can not be misused.
+//! fn test_unmapper<M: Unmap, T: UriBound>(unmap: &M, urid: URID<T>) {
+//!     assert_eq!(T::uri(), unmap.unmap(urid).unwrap());
+//! }
+//!
+//! // Create a simple mapper. The `HashURIDMapper` is thread-safe and can map and unmap all URIs.
+//! let map = HashURIDMapper::new();
+//!
+//! // Get the URIDs of the structs. You can use the collection or retrieve individual URIDs.
+//! let urids: MyURIDCollection = map.populate_collection().unwrap();
+//! let urid_a: URID<MyStructA> = map.map_type().unwrap();
+//!
+//! // You can also retrieve the URID of a single URI without a binding to a type.
+//! let urid_b: URID = map.map_str("https://rustup.rs").unwrap();
+//!
+//! test_unmapper(&map, urids.my_struct_a);
+//! test_unmapper(&map, urids.my_struct_b);
+//! test_unmapper(&map, urid_a);
+//! ```
 use std::cmp::{Ordering, PartialEq, PartialOrd};
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -25,22 +65,44 @@ pub type UriBuf = ::std::ffi::CString;
 
 /// A trait for types that can be identified by a URI.
 ///
-/// Every type that can be identified by a URI implements this trait, which makes the retrieval of these URIs as easy as the following:
+/// Every type that can be identified by a URI implements this trait. In most cases, you can use the `uri` attribute to implement `UriBound` safely and quickly:
 ///
-///     use urid::*;
+/// ```
+/// use urid::*;
 ///
-///     // Defining the struct
-///     #[uri("urn:my-struct")]
-///     pub struct MyStruct {
-///         a: f32,
-///     }
+/// // Defining the struct
+/// #[uri("urn:urid-example:my-struct")]
+/// pub struct MyStruct {
+///     a: f32,
+/// }
 ///
-///     // Retrieving the URI
-///     assert_eq!("urn:my-struct", MyStruct::uri().to_str().unwrap());
+/// // Retrieving the URI
+/// assert_eq!("urn:urid-example:my-struct", MyStruct::uri().to_str().unwrap());
+/// ```
+///
+/// However, in some cases, you need to implement `UriBound` manually, for example if the URI comes from a generated `sys` crate:
+///
+/// ```
+/// use urid::*;
+///
+/// // This URI is part of a generated `UriBound` crate:
+/// const A_FANCY_URI: &'static [u8] = b"urn:urid-example:fancy-uri\0";
+///
+/// // This struct is part of a safe wrapper crate:
+/// struct FancyStruct {
+///     _fancy_content: f32,
+/// }
+///
+/// unsafe impl UriBound for FancyStruct {
+///     const URI: &'static [u8] = A_FANCY_URI;
+/// }
+///
+/// assert_eq!("urn:urid-example:fancy-uri", FancyStruct::uri().to_str().unwrap())
+/// ```
 ///
 /// # Unsafety
 ///
-/// This trait is unsafe to implement since the [`URI`](#associatedconstant.URI) constant has some requirements that can not be enforced with Rust's type system.
+/// The [`URI`](#associatedconstant.URI) constant has to contain a null terminator (The `\0` character at the end), which is used by C programs to determine the end of the string. If you omit it, other parts of your program may violate memory access rules, which is considered undefined behaviour. Since this can not be statically checked by the compiler, this trait is unsafe to implement manually.
 pub unsafe trait UriBound {
     /// The URI of the type, safed as a byte slice
     ///
@@ -234,7 +296,7 @@ mod tests {
 
 /// A handle to map URIs to URIDs.
 pub trait Map {
-    /// Maps an URI to an `URID` that corresponds to it.
+    /// Maps an URI to a `URID` that corresponds to it.
     ///
     /// If the URI has not been mapped before, a new URID will be assigned.
     ///
@@ -247,6 +309,21 @@ pub trait Map {
     /// # Realtime usage
     /// This action may not be realtime-safe since it may involve locking mutexes or allocating dynamic memory. If you are working in a realtime environment, you should cache mapped URIDs in a [`URIDCollection`](trait.URIDCollection.html) and use it instead.
     fn map_uri(&self, uri: &Uri) -> Option<URID>;
+
+    /// Map an URI, encoded as a `str` to a `URID` that corresponds to it.
+    ///
+    /// This function copies the string into a vector, adds a null terminator and calls [`map_uri`](#tymethod.map_uri) with it. Therefore, the rules of `map_uri` apply here too.
+    ///
+    /// # Additional Errors
+    /// This method has the same error cases as `map_uri`, but also returns `None` if the string isn't an ASCII string or if the string can not be converted to a `Uri`.
+    fn map_str(&self, uri: &str) -> Option<URID> {
+        if !uri.is_ascii() {
+            return None;
+        }
+        let mut bytes: Vec<u8> = uri.as_bytes().to_owned();
+        bytes.push(0);
+        self.map_uri(Uri::from_bytes_with_nul(bytes.as_ref()).ok()?)
+    }
 
     /// Retrieve the URI of the bound and map it to a URID.
     ///

--- a/urid/src/lib.rs
+++ b/urid/src/lib.rs
@@ -27,16 +27,12 @@ pub type UriBuf = ::std::ffi::CString;
 ///
 /// Every type that can be identified by a URI implements this trait, which makes the retrieval of these URIs as easy as the following:
 ///
-///     use urid::UriBound;
+///     use urid::*;
 ///
 ///     // Defining the struct
+///     #[uri_bound("urn:my-struct")]
 ///     pub struct MyStruct {
 ///         a: f32,
-///     }
-///
-///     // Implementing `UriBound`
-///     unsafe impl UriBound for MyStruct {
-///         const URI: &'static [u8] = b"urn:my-struct\0";
 ///     }
 ///
 ///     // Retrieving the URI
@@ -79,17 +75,11 @@ where
 ///
 ///     # use urid::*;
 ///     // Defining all URI bounds.
+///     #[uri_bound("urn:my-type-a")]
 ///     struct MyTypeA;
 ///     
-///     unsafe impl UriBound for MyTypeA {
-///         const URI: &'static [u8] = b"urn:my-type-a\0";
-///     }
-///     
+///     #[uri_bound("urn:my-type-b")]
 ///     struct MyTypeB;
-///     
-///     unsafe impl UriBound for MyTypeB {
-///         const URI: &'static [u8] = b"urn:my-type-b\0";
-///     }
 ///
 ///     // Defining the collection.
 ///     #[derive(URIDCollection)]

--- a/urid/src/lib.rs
+++ b/urid/src/lib.rs
@@ -30,7 +30,7 @@ pub type UriBuf = ::std::ffi::CString;
 ///     use urid::*;
 ///
 ///     // Defining the struct
-///     #[uri_bound("urn:my-struct")]
+///     #[uri("urn:my-struct")]
 ///     pub struct MyStruct {
 ///         a: f32,
 ///     }
@@ -75,10 +75,10 @@ where
 ///
 ///     # use urid::*;
 ///     // Defining all URI bounds.
-///     #[uri_bound("urn:my-type-a")]
+///     #[uri("urn:my-type-a")]
 ///     struct MyTypeA;
 ///     
-///     #[uri_bound("urn:my-type-b")]
+///     #[uri("urn:my-type-b")]
 ///     struct MyTypeB;
 ///
 ///     // Defining the collection.

--- a/urid/tests/urid.rs
+++ b/urid/tests/urid.rs
@@ -3,11 +3,8 @@ use urid::*;
 #[uri_bound("urn:my-type-a")]
 struct MyTypeA;
 
+#[uri_bound("urn:my-type-b")]
 struct MyTypeB;
-
-unsafe impl UriBound for MyTypeB {
-    const URI: &'static [u8] = b"urn:my-type-b\0";
-}
 
 #[test]
 fn test_map() {

--- a/urid/tests/urid.rs
+++ b/urid/tests/urid.rs
@@ -1,10 +1,7 @@
 use urid::*;
 
+#[uri_bound("urn:my-type-a")]
 struct MyTypeA;
-
-unsafe impl UriBound for MyTypeA {
-    const URI: &'static [u8] = b"urn:my-type-a\0";
-}
 
 struct MyTypeB;
 

--- a/urid/tests/urid.rs
+++ b/urid/tests/urid.rs
@@ -1,9 +1,9 @@
 use urid::*;
 
-#[uri_bound("urn:my-type-a")]
+#[uri("urn:my-type-a")]
 struct MyTypeA;
 
-#[uri_bound("urn:my-type-b")]
+#[uri("urn:my-type-b")]
 struct MyTypeB;
 
 #[test]


### PR DESCRIPTION
This pull request closes #46 by adding a procedural macro that implements `UriBound` for a type.

The syntax looks like that:
```Rust
#[uri("https://google.com")]
struct Google;
```
This macro parses the argument, assures that it is a ASCII string literal, adds a null terminator and uses this URI to implement `UriBound`. It is only useful for non-generic types where the URI is given as a literal. Most of the `UriBound` implementation in the project use URIs from the `lv2-sys` crate and therefore don't need such a macro, and supporting generics would require a lot of detailed token tree manipulations that aren't needed for the general case.

I really struggled with this goal the last time I tried it, but now, it was rather easy.