### PR TITLE
Improving the re-export crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,66 @@ repository = "https://github.com/RustAudio/rust-lv2"
 travis-ci = { repository = "RustAudio/rust-lv2", branch = "master" }
 maintenance = { status = "actively-developed" }
 
-[dependencies]
-lv2-atom = "1.0.0"
-lv2-core = "1.0.0"
-lv2-midi = "1.0.0"
-lv2-time = "0.1.0"
-lv2-units = "0.1.0"
-lv2-urid = "1.0.0"
-lv2-state = "1.0.0"
-lv2-worker = "0.1.0"
+[dependencies.lv2-atom]
+version = "1.0.0"
+optional = true
+
+[dependencies.lv2-core]
+version = "1.0.0"
+optional = true
+
+[dependencies.lv2-midi]
+version = "1.0.0"
+optional = true
+
+[dependencies.lv2-time]
+version = "0.1.0"
+optional = true
+
+[dependencies.lv2-units]
+version = "0.1.0"
+optional = true
+
+[dependencies.urid]
+version = "0.1.0"
+optional = true
+
+[dependencies.lv2-urid]
+version = "1.0.0"
+optional = true
+
+[dependencies.lv2-state]
+version = "1.0.0"
+optional = true
+
+[dependencies.lv2-worker]
+version = "0.1.0"
+optional = true
+
+[features]
+default = ["plugin"]
+minimal_plugin = [
+    "lv2-core",
+    "urid",
+]
+plugin = [
+    "minimal_plugin",
+    "lv2-atom",
+    "lv2-midi",
+    "lv2-urid",
+]
+full = [
+    "lv2-atom",
+    "lv2-core",
+    "lv2-midi",
+    "lv2-time",
+    "lv2-units",
+    "urid",
+    "lv2-urid",
+    "lv2-state",
+    "lv2-worker",
+]
+wmidi = ["lv2-midi", "lv2-midi/wmidi"]
 
 [workspace]
 members = [
@@ -54,7 +105,3 @@ urid = { path = "urid" }
 urid-derive = { path = "urid/derive" }
 lv2-urid = { path = "urid/lv2-urid" }
 lv2-worker = { path = "worker" }
-
-[features]
-default = []
-wmidi = ["lv2-midi/wmidi"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,27 @@
 //! Since this crate depends on `-sys` crates that use `bindgen` to create the C API bindings,
 //! you need to have clang installed on your machine.
 
+pub mod prelude {
+    #[cfg(feature = "lv2-atom")]
+    pub use ::lv2_atom::prelude::*;
+    #[cfg(feature = "lv2-core")]
+    pub use ::lv2_core::prelude::*;
+    #[cfg(feature = "lv2-midi")]
+    pub use ::lv2_midi::prelude::*;
+    #[cfg(feature = "lv2-state")]
+    pub use ::lv2_state::*;
+    #[cfg(feature = "lv2-time")]
+    pub use ::lv2_time::prelude::*;
+    #[cfg(feature = "lv2-units")]
+    pub use ::lv2_units::prelude::*;
+    #[cfg(feature = "lv2-urid")]
+    pub use ::lv2_urid::*;
+    #[cfg(feature = "urid")]
+    pub use ::urid::*;
+    #[cfg(feature = "lv2-work")]
+    pub use ::lv2_worker::prelude::*;
+}
+
 #[cfg(feature = "lv2-atom")]
 pub mod atom {
     pub use lv2_atom::*;
@@ -76,25 +97,4 @@ pub mod urid {
 #[cfg(feature = "lv2-worker")]
 pub mod worker {
     pub use lv2_worker::*;
-}
-
-pub mod prelude {
-    #[cfg(feature = "lv2-atom")]
-    pub use ::lv2_atom::prelude::*;
-    #[cfg(feature = "lv2-core")]
-    pub use ::lv2_core::prelude::*;
-    #[cfg(feature = "lv2-midi")]
-    pub use ::lv2_midi::prelude::*;
-    #[cfg(feature = "lv2-state")]
-    pub use ::lv2_state::*;
-    #[cfg(feature = "lv2-time")]
-    pub use ::lv2_time::prelude::*;
-    #[cfg(feature = "lv2-units")]
-    pub use ::lv2_units::prelude::*;
-    #[cfg(feature = "lv2-urid")]
-    pub use ::lv2_urid::*;
-    #[cfg(feature = "urid")]
-    pub use ::urid::*;
-    #[cfg(feature = "lv2-work")]
-    pub use ::lv2_worker::prelude::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,13 +35,66 @@
 //! Since this crate depends on `-sys` crates that use `bindgen` to create the C API bindings,
 //! you need to have clang installed on your machine.
 
-#![deny(missing_docs)]
+#[cfg(feature = "lv2-atom")]
+pub mod atom {
+    pub use lv2_atom::*;
+}
 
-pub extern crate lv2_atom as atom;
-pub extern crate lv2_core as core;
-pub extern crate lv2_midi as midi;
-pub extern crate lv2_state as state;
-pub extern crate lv2_time as time;
-pub extern crate lv2_units as units;
-pub extern crate lv2_urid as urid;
-pub extern crate lv2_worker as worker;
+#[cfg(feature = "lv2-core")]
+pub mod core {
+    pub use lv2_core::*;
+}
+
+#[cfg(feature = "lv2-midi")]
+pub mod midi {
+    pub use lv2_midi::*;
+}
+
+#[cfg(feature = "lv2-state")]
+pub mod state {
+    pub use lv2_state::*;
+}
+
+#[cfg(feature = "lv2-time")]
+pub mod time {
+    pub use lv2_time::*;
+}
+
+#[cfg(feature = "lv2-units")]
+pub mod units {
+    pub use lv2_units::*;
+}
+
+#[cfg(any(feature = "lv2-urid", feature = "urid"))]
+pub mod urid {
+    #[cfg(feature = "urid")]
+    pub use urid::*;
+    #[cfg(feature = "lv2-urid")]
+    pub use lv2_urid::*;
+}
+
+#[cfg(feature = "lv2-worker")]
+pub mod worker {
+    pub use lv2_worker::*;
+}
+
+pub mod prelude {
+    #[cfg(feature = "lv2-atom")]
+    pub use ::lv2_atom::prelude::*;
+    #[cfg(feature = "lv2-core")]
+    pub use ::lv2_core::prelude::*;
+    #[cfg(feature = "lv2-midi")]
+    pub use ::lv2_midi::prelude::*;
+    #[cfg(feature = "lv2-state")]
+    pub use ::lv2_state::*;
+    #[cfg(feature = "lv2-time")]
+    pub use ::lv2_time::prelude::*;
+    #[cfg(feature = "lv2-units")]
+    pub use ::lv2_units::prelude::*;
+    #[cfg(feature = "lv2-urid")]
+    pub use ::lv2_urid::*;
+    #[cfg(feature = "urid")]
+    pub use ::urid::*;
+    #[cfg(feature = "lv2-work")]
+    pub use ::lv2_worker::prelude::*;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,10 +50,10 @@ pub mod prelude {
     pub use ::lv2_units::prelude::*;
     #[cfg(feature = "lv2-urid")]
     pub use ::lv2_urid::*;
-    #[cfg(feature = "urid")]
-    pub use ::urid::*;
     #[cfg(feature = "lv2-work")]
     pub use ::lv2_worker::prelude::*;
+    #[cfg(feature = "urid")]
+    pub use ::urid::*;
 }
 
 #[cfg(feature = "lv2-atom")]
@@ -88,10 +88,10 @@ pub mod units {
 
 #[cfg(any(feature = "lv2-urid", feature = "urid"))]
 pub mod urid {
-    #[cfg(feature = "urid")]
-    pub use urid::*;
     #[cfg(feature = "lv2-urid")]
     pub use lv2_urid::*;
+    #[cfg(feature = "urid")]
+    pub use urid::*;
 }
 
 #[cfg(feature = "lv2-worker")]


### PR DESCRIPTION
This pull request boosts the usability of the root re-export crate. Instead of simply depending on all sub-crates and re-exporting them via `pub extern crate`, it now optionally depends on all crates and `pub use`s them. This leads to multiple quality-of-life enhancements:

* Plugin creators only need to depend on one crate, but still
  * have the choice which crates to use,
  * see a clear module <-> specification relationship.
* Plugin creators don't need to investigate which sub-crates received updates and change their `Cargo.toml` accordingly. They only need to update the dependency to `lv2`.
* Feature sets can be created for common scenarios. I've already included a minimal plugin set and a standard plugin set, but in the future, there could also be a host set.
* The internal structures are hidden. For example, the `urid` and `lv2-urid` crates are unified in a module to improve understandability, but still are separate crates and can be used separately.
* Cross-crate links in documentations are possible now.
* It covers up my mistake of giving several crates a major version, although they obviously aren't stable yet. Now, since users only depend on `lv2`, which doesn't have a major version, they know that it is unstable.

However, this requires a lot of documentation to be re-written and guidelines to be changed. I would do that in a second pull request since I want to spice up the docs anyways.