### PR TITLE
Making all macros unhygenic

### DIFF
--- a/atom/src/lib.rs
+++ b/atom/src/lib.rs
@@ -98,7 +98,7 @@ pub mod prelude {
 }
 
 use space::*;
-use urid::{URIDCollection, UriBound, URID};
+use urid::*;
 
 #[derive(Clone, URIDCollection)]
 /// Collection with the URIDs of all `UriBound`s in this crate.

--- a/core/derive/src/lv2_descriptors.rs
+++ b/core/derive/src/lv2_descriptors.rs
@@ -26,16 +26,16 @@ impl Lv2InstanceDescriptor {
     pub fn make_instance_descriptor_impl(&self) -> impl ::quote::ToTokens {
         let plugin_type = &self.plugin_type;
         quote! {
-            unsafe impl ::lv2_core::plugin::PluginInstanceDescriptor for #plugin_type {
-                const DESCRIPTOR: ::lv2_core::prelude::LV2_Descriptor = ::lv2_core::prelude::LV2_Descriptor {
+            unsafe impl PluginInstanceDescriptor for #plugin_type {
+                const DESCRIPTOR: LV2_Descriptor = LV2_Descriptor {
                     URI: Self::URI.as_ptr() as *const u8 as *const ::std::os::raw::c_char,
-                    instantiate: Some(::lv2_core::plugin::PluginInstance::<Self>::instantiate),
-                    connect_port: Some(::lv2_core::plugin::PluginInstance::<Self>::connect_port),
-                    activate: Some(::lv2_core::plugin::PluginInstance::<Self>::activate),
-                    run: Some(::lv2_core::plugin::PluginInstance::<Self>::run),
-                    deactivate: Some(::lv2_core::plugin::PluginInstance::<Self>::deactivate),
-                    cleanup: Some(::lv2_core::plugin::PluginInstance::<Self>::cleanup),
-                    extension_data: Some(::lv2_core::plugin::PluginInstance::<Self>::extension_data)
+                    instantiate: Some(PluginInstance::<Self>::instantiate),
+                    connect_port: Some(PluginInstance::<Self>::connect_port),
+                    activate: Some(PluginInstance::<Self>::activate),
+                    run: Some(PluginInstance::<Self>::run),
+                    deactivate: Some(PluginInstance::<Self>::deactivate),
+                    cleanup: Some(PluginInstance::<Self>::cleanup),
+                    extension_data: Some(PluginInstance::<Self>::extension_data)
                 };
             }
         }
@@ -49,7 +49,7 @@ impl Lv2InstanceDescriptor {
     fn make_index_match_arm(&self, index: u32) -> impl ::quote::ToTokens {
         let plugin_type = &self.plugin_type;
         quote! {
-            #index => &<#plugin_type as ::lv2_core::plugin::PluginInstanceDescriptor>::DESCRIPTOR,
+            #index => &<#plugin_type as PluginInstanceDescriptor>::DESCRIPTOR,
         }
     }
 }
@@ -103,7 +103,7 @@ impl Lv2InstanceDescriptorList {
             ///
             /// The returned pointer references a constant and there is valid as long as the library is loaded.
             #[no_mangle]
-            pub unsafe extern "C" fn lv2_descriptor(index: u32) -> *const ::lv2_core::prelude::LV2_Descriptor {
+            pub unsafe extern "C" fn lv2_descriptor(index: u32) -> *const LV2_Descriptor {
                 match index {
                     #(#index_matchers)*
                     _ => ::std::ptr::null()

--- a/core/src/extension.rs
+++ b/core/src/extension.rs
@@ -145,7 +145,7 @@ macro_rules! match_extensions {
     ($uri:expr, $($descriptor:ty),*) => {
         match ($uri).to_bytes_with_nul() {
             $(
-                <$descriptor as ::urid::UriBound>::URI => Some(<$descriptor as ::lv2_core::extension::ExtensionDescriptor>::INTERFACE as &'static dyn std::any::Any),
+                <$descriptor as UriBound>::URI => Some(<$descriptor as ExtensionDescriptor>::INTERFACE as &'static dyn ::std::any::Any),
             )*
             _ => None,
         }

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -1,7 +1,7 @@
 //! Prelude for wildcard use, containing many important types.
+pub use crate::extension::ExtensionDescriptor;
 pub use crate::feature::{FeatureCache, FeatureCollection, MissingFeatureError, ThreadingClass};
 pub use crate::match_extensions;
-pub use crate::extension::ExtensionDescriptor;
 pub use crate::plugin::{
     lv2_descriptors, Plugin, PluginInfo, PluginInstance, PluginInstanceDescriptor, PortCollection,
 };

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -1,6 +1,9 @@
 //! Prelude for wildcard use, containing many important types.
 pub use crate::feature::{FeatureCache, FeatureCollection, MissingFeatureError, ThreadingClass};
 pub use crate::match_extensions;
-pub use crate::plugin::{lv2_descriptors, Plugin, PluginInfo, PortCollection};
+pub use crate::extension::ExtensionDescriptor;
+pub use crate::plugin::{
+    lv2_descriptors, Plugin, PluginInfo, PluginInstance, PluginInstanceDescriptor, PortCollection,
+};
 pub use crate::port::*;
 pub use crate::sys::LV2_Descriptor;

--- a/urid/derive/src/uri_bound.rs
+++ b/urid/derive/src/uri_bound.rs
@@ -60,7 +60,7 @@ pub fn impl_uri_bound(attr: TokenStream, mut item: TokenStream) -> TokenStream {
     let uri = get_uri(attr);
 
     let implementation: TokenStream = quote! {
-        unsafe impl ::urid::UriBound for #ident {
+        unsafe impl UriBound for #ident {
             const URI: &'static [u8] = #uri;
         }
     }

--- a/urid/derive/src/urid_collection_derive.rs
+++ b/urid/derive/src/urid_collection_derive.rs
@@ -18,8 +18,8 @@ pub fn urid_collection_derive_impl(input: TokenStream) -> TokenStream {
         .map(|ident| quote! {#ident: map.populate_collection()?,});
 
     let implementation = quote! {
-        impl ::urid::URIDCollection for #struct_name {
-            fn from_map<M: ::urid::Map + ?Sized>(map: &M) -> Option<Self> {
+        impl URIDCollection for #struct_name {
+            fn from_map<M: Map + ?Sized>(map: &M) -> Option<Self> {
                 Some(Self {
                     #(#field_inits)*
                 })


### PR DESCRIPTION
This pull requests makes all macros unhygenic. To be more precise: With this pull request, all macros depend that the surrounding scope is `use`ing the right prelude module.

This fixes the problem that the macros don't work anymore when used through the re-export crate. Updated documentation is about to follow.