### PR TITLE
A host feature can not be used in multiple feature collections

### DIFF
--- a/core/src/feature/cache.rs
+++ b/core/src/feature/cache.rs
@@ -54,8 +54,8 @@ impl<'a> FeatureCache<'a> {
     ) -> Result<T, MissingFeatureError> {
         T::from_resolved_feature(
             self.internal
-                .remove(F::uri())
-                .and_then(|ptr| unsafe { F::from_feature_ptr(ptr, class) }),
+                .get(F::uri())
+                .and_then(|ptr| unsafe { F::from_feature_ptr(*ptr, class) }),
         )
     }
 }


### PR DESCRIPTION
As it said in commit, the way features was retrieved was preventing to retrieve several time the same feature for different threading class. It's needed to correctly implement the log spec.