### PR TITLE
Cloning the features cache to allow features to be used in both feature collections

### DIFF
--- a/core/src/feature/cache.rs
+++ b/core/src/feature/cache.rs
@@ -8,6 +8,7 @@ use std::iter::Map;
 /// At initialization time, a raw LV2 plugin receives a null-terminated array containing all requested host features. Obviously, this is not suited for safe Rust code and therefore, it needs an abstraction layer.
 ///
 /// Internally, this struct contains a hash map which is filled the raw LV2 feature descriptors. Using this map, methods are defined to identify and retrieve features.
+#[derive(Clone)]
 pub struct FeatureCache<'a> {
     internal: HashMap<&'a CStr, *const c_void>,
 }

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -131,17 +131,21 @@ impl<T: Plugin> PluginInstance<T> {
         };
 
         // Collect the supported features.
-        let mut feature_cache = FeatureCache::from_raw(features);
-        let mut init_features =
-            match T::InitFeatures::from_cache(&mut feature_cache, ThreadingClass::Instantiation) {
-                Ok(f) => f,
-                Err(e) => {
-                    eprintln!("{}", e);
-                    return std::ptr::null_mut();
-                }
-            };
+        let mut init_features_cache = FeatureCache::from_raw(features);
+        let mut audio_features_cache = init_features_cache.clone();
+
+        let mut init_features = match T::InitFeatures::from_cache(
+            &mut init_features_cache,
+            ThreadingClass::Instantiation,
+        ) {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("{}", e);
+                return std::ptr::null_mut();
+            }
+        };
         let audio_features =
-            match T::AudioFeatures::from_cache(&mut feature_cache, ThreadingClass::Audio) {
+            match T::AudioFeatures::from_cache(&mut audio_features_cache, ThreadingClass::Audio) {
                 Ok(f) => f,
                 Err(e) => {
                     eprintln!("{}", e);

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -77,13 +77,13 @@ pub trait Plugin: UriBound + Sized + Send + Sync + 'static {
 #[repr(C)]
 pub struct PluginInstance<T: Plugin> {
     /// The plugin instance.
-    pub instance: T,
+    instance: T,
     /// A temporary storage for all ports of the plugin.
-    pub connections: <T::Ports as PortCollection>::Cache,
+    connections: <T::Ports as PortCollection>::Cache,
     /// All features that may be used in the initialization threading class.
-    pub init_features: T::InitFeatures,
+    init_features: T::InitFeatures,
     /// All features that may be used in the audio threading class.
-    pub audio_features: T::AudioFeatures,
+    audio_features: T::AudioFeatures,
 }
 
 impl<T: Plugin> PluginInstance<T> {
@@ -246,6 +246,25 @@ impl<T: Plugin> PluginInstance<T> {
         } else {
             std::ptr::null()
         }
+    }
+
+    /// Retrieve the internal plugin.
+    pub fn plugin_handle(&mut self) -> &mut T {
+        &mut self.instance
+    }
+
+    /// Retrieve the required handles to execute an Initialization class method.
+    /// 
+    /// This method can be used by extensions to call an extension method in the Initialization threading class and provide it the host features for that class.
+    pub fn init_class_handle(&mut self) -> (&mut T, &mut T::InitFeatures) {
+        (&mut self.instance, &mut self.init_features)
+    }
+
+    /// Retrieve the required handles to execute an Audio class method.
+    /// 
+    /// This method can be used by extensions to call an extension method in the Audio threading class and provide it the host features for that class.
+    pub fn audio_class_handle(&mut self) -> (&mut T, &mut T::AudioFeatures) {
+        (&mut self.instance, &mut self.audio_features)
     }
 }
 

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -437,10 +437,8 @@ impl<P: Worker> WorkerDescriptor<P> {
             return lv2_sys::LV2_Worker_Status_LV2_WORKER_ERR_UNKNOWN;
         }
 
-        match plugin_instance
-            .instance
-            .work_response(response_data, &mut plugin_instance.audio_features)
-        {
+        let (instance, features) = plugin_instance.audio_class_handle();
+        match instance.work_response(response_data, features) {
             Ok(()) => lv2_sys::LV2_Worker_Status_LV2_WORKER_SUCCESS,
             Err(WorkerError::Unknown) => lv2_sys::LV2_Worker_Status_LV2_WORKER_ERR_UNKNOWN,
             Err(WorkerError::NoSpace) => lv2_sys::LV2_Worker_Status_LV2_WORKER_ERR_NO_SPACE,
@@ -450,10 +448,8 @@ impl<P: Worker> WorkerDescriptor<P> {
     /// Extern unsafe version of `end_run` method actually called by the host
     unsafe extern "C" fn extern_end_run(handle: lv2_sys::LV2_Handle) -> lv2_sys::LV2_Worker_Status {
         if let Some(plugin_instance) = (handle as *mut PluginInstance<P>).as_mut() {
-            match plugin_instance
-                .instance
-                .end_run(&mut plugin_instance.audio_features)
-            {
+            let (instance, features) = plugin_instance.audio_class_handle();
+            match instance.end_run(features) {
                 Ok(()) => lv2_sys::LV2_Worker_Status_LV2_WORKER_SUCCESS,
                 Err(WorkerError::Unknown) => lv2_sys::LV2_Worker_Status_LV2_WORKER_ERR_UNKNOWN,
                 Err(WorkerError::NoSpace) => lv2_sys::LV2_Worker_Status_LV2_WORKER_ERR_NO_SPACE,


### PR DESCRIPTION
This PR is a reply to #62 and solves the bug that a feature can not be used both in the `InitFeatures` collection and the `AudioFeatures` collection. My solution is to clone the feature cache before the `InitFeatures` are retrieved and then to retrieve the `AudioFeatures` from the clone.

This is sound since there may never be two mutable references to the same feature outside of `PluginInstance`: The core plugin methods only receive a mutable reference to the feature collections and therefore can not keep a reference to a feature outside of these methods. Extensions can only retrieve the plugin either with the `InitFeatures` or the `AudioFeatures`, but not both at the same time.