### PR TITLE
Atom tweaks

### DIFF
--- a/atom/Cargo.toml
+++ b/atom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lv2-atom"
-version = "1.1.1"
+version = "1.1.0"
 authors = ["Jan-Oliver 'Janonard' Opdenhövel <jan.opdenhoevel@protonmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/atom/Cargo.toml
+++ b/atom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lv2-atom"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Jan-Oliver 'Janonard' Opdenhövel <jan.opdenhoevel@protonmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/atom/src/lib.rs
+++ b/atom/src/lib.rs
@@ -103,6 +103,7 @@ use urid::*;
 #[derive(Clone, URIDCollection)]
 /// Collection with the URIDs of all `UriBound`s in this crate.
 pub struct AtomURIDCollection {
+    pub blank: URID<object::Blank>,
     pub double: URID<scalar::Double>,
     pub float: URID<scalar::Float>,
     pub int: URID<scalar::Int>,
@@ -203,5 +204,12 @@ impl<'a> UnidentifiedAtom<'a> {
             .split_atom_body(urid)
             .map(|(body, _)| body)
             .and_then(|body| A::read(body, parameter))
+    }
+
+    /// Retrieve the type URID of the atom.
+    /// 
+    /// This can be used to identify atoms without actually reading them.
+    pub fn type_urid(self) -> Option<URID> {
+        self.space.split_type::<sys::LV2_Atom>().and_then(|(header, _)| URID::new(header.type_))
     }
 }

--- a/atom/src/object.rs
+++ b/atom/src/object.rs
@@ -135,14 +135,14 @@ where
 /// Alias of `Object`, used by older hosts.
 ///
 /// A blank object is an object that isn't an instance of a class. The [specification recommends](https://lv2plug.in/ns/ext/atom/atom.html#Blank) to use an [`Object`](struct.Object.html) with an id of `None`, but some hosts still use it and therefore, it's included in this library.
+/// 
+/// If you want to read an object, you should also support `Blank`s, but if you want to write an object, you should always use `Object`.
 pub struct Blank;
 
-#[allow(deprecated)]
 unsafe impl UriBound for Blank {
     const URI: &'static [u8] = sys::LV2_ATOM__Blank;
 }
 
-#[allow(deprecated)]
 impl<'a, 'b> Atom<'a, 'b> for Blank
 where
     'a: 'b,

--- a/atom/src/object.rs
+++ b/atom/src/object.rs
@@ -135,7 +135,6 @@ where
 /// Deprecated alias of `Object`
 ///
 /// A blank object is an object that isn't an instance of a class. The [specification recommends](https://lv2plug.in/ns/ext/atom/atom.html#Blank) to use an [`Object`](struct.Object.html) with an id of `None`, but some hosts still use it and therefore, it's included in this library.
-#[deprecated]
 pub struct Blank;
 
 #[allow(deprecated)]

--- a/atom/src/object.rs
+++ b/atom/src/object.rs
@@ -132,7 +132,7 @@ where
     }
 }
 
-/// Deprecated alias of `Object`
+/// Alias of `Object`, used by older hosts.
 ///
 /// A blank object is an object that isn't an instance of a class. The [specification recommends](https://lv2plug.in/ns/ext/atom/atom.html#Blank) to use an [`Object`](struct.Object.html) with an id of `None`, but some hosts still use it and therefore, it's included in this library.
 pub struct Blank;


### PR DESCRIPTION
These are some small enhancement for `lv2-atom` I introduced for the metronome example:
* The `UnidentifiedAtom` has a method to retrieve the type URID of the atom. That might be useful for debugging or to identify an atom without actually reading it.
* `Blank` isn't deprecated anymore since it conveyed the wrong meaning: Some "older" hosts (e.g. Carla) send `Blank` objects instead of regular objects and a plugin has to retrieve both. They are deprecated in a way that a new plugin shouldn't send them, but plugins should also accept them and `Blank`s won't be removed anytime soon.