### PR TITLE
Fixing the examples

### DIFF
--- a/docs/amp/Cargo.toml
+++ b/docs/amp/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 # Plugins are dynamic libraries. This setting tells cargo to export it this way.
 [lib]
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 # Rust-LV2 is a network of individual sub-crates with different version numbers and histories.
 # However, most plugins don't need to deal with them directly. Instead, they use the re-export crate

--- a/docs/fifths/Cargo.toml
+++ b/docs/fifths/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jan-Oliver 'Janonard' Opdenhövel <jan.opdenhoevel@protonmail.com>"]
 edition = "2018"
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 wmidi = "3.1.0"

--- a/docs/metro/Cargo.toml
+++ b/docs/metro/Cargo.toml
@@ -6,7 +6,7 @@ license = "ISC"
 edition = "2018"
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 # This is the first time we need a non-default LV2 feature. In this case, this is the `lv2-time` crate.
 [dependencies]

--- a/docs/metro/src/pipes.rs
+++ b/docs/metro/src/pipes.rs
@@ -224,7 +224,7 @@ where
     fn retrieve_next_event(&mut self) {
         self.next_event = None;
         if let Some((index, item)) = self.sequence.next() {
-            if index > self.index {
+            if index >= self.index {
                 self.next_event = Some((index, item));
             }
         }

--- a/docs/midigate/Cargo.toml
+++ b/docs/midigate/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Jan-Oliver 'Janonard' Opdenhövel <jan.opdenhoevel@protonmail.com>"]
 edition = "2018"
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 wmidi = "3.1.0"

--- a/install_examples.sh
+++ b/install_examples.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env sh
-cargo build --all --release
+set -e -x
 
 rm -rf target/lv2
 mkdir -p target/lv2
 
+cargo build -p amp --release
 cp -r docs/amp/eg-amp-rs.lv2 target/lv2/eg-amp-rs.lv2
 cp target/release/libamp.so target/lv2/eg-amp-rs.lv2
 
+cargo build -p midigate --release
 cp -r docs/midigate/eg-midigate-rs.lv2 target/lv2/eg-midigate-rs.lv2
 cp target/release/libmidigate.so target/lv2/eg-midigate-rs.lv2
 
+cargo build -p fifths --release
 cp -r docs/fifths/eg-fifths-rs.lv2 target/lv2/eg-fifths-rs.lv2
 cp target/release/libfifths.so target/lv2/eg-fifths-rs.lv2
 
+cargo build -p metro --release
 cp -r docs/metro/eg-metro-rs.lv2 target/lv2/eg-metro-rs.lv2
 cp target/release/libmetro.so target/lv2/eg-metro-rs.lv2
 


### PR DESCRIPTION
I've discovered and fixed a) why all example plugins haven't been working lately and b) why @YruamaLairba and I reported different library sizes for the plugins: The `dylib` crate type now creates a dynamic library which supposed to be loaded by a Rust program and therefore dynamically links to the current `std` library. Libraries that are supposed be loaded by non-Rust programs should use the `cdylib` crate type now, which creates distributable shared libraries. They are about 0.9 MB in size, which is okay from my point of view.

I've also fixed a bug in the metro plugin that ignored all events with an index of 0.