### PR TITLE
Replace regex usage by function from std

### DIFF
--- a/urid/derive/Cargo.toml
+++ b/urid/derive/Cargo.toml
@@ -20,5 +20,3 @@ proc-macro = true
 syn = {version = "1.0.5", features = ["full"]}
 quote = "1.0.2"
 proc-macro2 = "1.0.9"
-regex = "1.3.5"
-lazy_static = "1.4.0"

--- a/urid/derive/src/uri_bound.rs
+++ b/urid/derive/src/uri_bound.rs
@@ -40,11 +40,8 @@ fn get_uri(attr: TokenStream) -> Literal {
     }
     //Remove the enclosing "" to get the uri
     let uri = String::from(attr.get(1..attr.len() - 1).expect(PARSING_ERROR));
-    if uri.contains(|c: char| c.is_ascii_whitespace()) {
-        panic!("A URI can't contain whitespace");
-    }
-    if !uri.is_ascii() {
-        panic!("A URI has to be an ASCII string");
+    if uri.contains("\\0") {
+        panic!("Unexpected Null terminator");
     }
 
     let mut uri_vec: Vec<u8> = Vec::with_capacity(uri.len() + 1);

--- a/urid/derive/src/uri_bound.rs
+++ b/urid/derive/src/uri_bound.rs
@@ -1,8 +1,6 @@
-use lazy_static::lazy_static;
 use proc_macro::TokenStream;
 use proc_macro2::Literal;
 use quote::quote;
-use regex::Regex;
 use syn::{parse, Ident, Item};
 
 /// Get the identity of the item we have to implement `UriBound` for.
@@ -30,19 +28,21 @@ fn get_type_ident(item: TokenStream) -> Ident {
 ///
 /// This includes multiple checks to assure that the literal is formatted correctly.
 fn get_uri(attr: TokenStream) -> Literal {
-    lazy_static! {
-        static ref GET_STRING_RE: Regex = Regex::new(r#"^"(.*)"$"#).unwrap();
-    }
-
     const PARSING_ERROR: &str = "A URI has to be a string literal";
 
     if parse::<Literal>(attr.clone()).is_err() {
         panic!(PARSING_ERROR);
     }
-
+    //check if it's a litteral string
     let attr = attr.to_string();
-    let captures = GET_STRING_RE.captures(attr.as_str()).expect(PARSING_ERROR);
-    let uri = captures.get(1).expect(PARSING_ERROR).as_str();
+    if !attr.starts_with('"') || !attr.ends_with('"') {
+        panic!(PARSING_ERROR);
+    }
+    //Remove the enclosing "" to get the uri
+    let uri = String::from(attr.get(1..attr.len() - 1).expect(PARSING_ERROR));
+    if uri.contains(|c: char| c.is_ascii_whitespace()) {
+        panic!("A URI can't contain whitespace");
+    }
     if !uri.is_ascii() {
         panic!("A URI has to be an ASCII string");
     }


### PR DESCRIPTION
I tried to remove regex from dependency graph to reduce compilation time. On my computer, It take 26s instead 38 in debug and 1min14 instead 1min54. More than 30% of time-saving.