### PR TITLE
Fixing the installation script

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ and the book will be written to `export/README.md`.
 
 ## Building and installing the sample plugins
 
-Every sample is a self-contained Rust crate; You can simply build it with cargo. If you want to install the samples on your machine, you can run `install.sh`. This will build the crates, bundle them and copy them to `~/.lv2`.
+Every sample is a self-contained Rust crate; You can simply build it with cargo. If you want to install the samples on your machine, you can run `install_examples.sh`. This will build the crates, bundle them and copy them to `~/.lv2`.
 
 The compiler might complain that "profiles for the non root package will be ignored", which you can safely ignore. Some examples have a profile section to show how to enable link-time optimizations, but these profile section don't have an effect.
 

--- a/install_examples.sh
+++ b/install_examples.sh
@@ -1,25 +1,33 @@
 #!/usr/bin/env sh
+#
+# Installation script for the example plugins.
+#
+# This script builds every plugin and installs it into `~/.lv2`, which is the standard path for user
+# plugins for Linux. The first argument of the script is interpreted as the target to build the
+# plugins for. If you leave it out, the default target of your Rust installation is used.
+export TARGET_PATH="target"
+test ! -z "$1" && export TARGET_OPT="--target $1" TARGET_PATH="target/$1"
+
 set -e -x
-[[ ! -z $TARGET ]] || (export TARGET="x86_64-unknown-linux-gnu")
 
 rm -rf target/lv2
 mkdir -p target/lv2
 
-cargo build -p amp --release --target $TARGET
+cargo build -p amp --release $TARGET_OPT
 cp -r docs/amp/eg-amp-rs.lv2 target/lv2/eg-amp-rs.lv2
-cp target/$TARGET/release/libamp.so target/lv2/eg-amp-rs.lv2
+cp $TARGET_PATH/release/libamp.so target/lv2/eg-amp-rs.lv2
 
-cargo build -p midigate --release --target $TARGET
+cargo build -p midigate --release $TARGET_OPT
 cp -r docs/midigate/eg-midigate-rs.lv2 target/lv2/eg-midigate-rs.lv2
-cp target/$TARGET/release/libmidigate.so target/lv2/eg-midigate-rs.lv2
+cp $TARGET_PATH/release/libmidigate.so target/lv2/eg-midigate-rs.lv2
 
-cargo build -p fifths --release --target $TARGET
+cargo build -p fifths --release $TARGET_OPT
 cp -r docs/fifths/eg-fifths-rs.lv2 target/lv2/eg-fifths-rs.lv2
-cp target/$TARGET/release/libfifths.so target/lv2/eg-fifths-rs.lv2
+cp $TARGET_PATH/release/libfifths.so target/lv2/eg-fifths-rs.lv2
 
-cargo build -p metro --release --target $TARGET
+cargo build -p metro --release $TARGET_OPT
 cp -r docs/metro/eg-metro-rs.lv2 target/lv2/eg-metro-rs.lv2
-cp target/$TARGET/release/libmetro.so target/lv2/eg-metro-rs.lv2
+cp $TARGET_PATH/release/libmetro.so target/lv2/eg-metro-rs.lv2
 
 mkdir -p ~/.lv2
 cp -r target/lv2/* ~/.lv2


### PR DESCRIPTION
The way the installation script handles targets is faulty.

Now, the first argument of the script is interpreted as the target to build and if it's left out, no target flag is used at all.