### PR TITLE
Add sample_count to Plugin run method

### DIFF
--- a/atom/tests/atom_integration.rs
+++ b/atom/tests/atom_integration.rs
@@ -42,7 +42,7 @@ impl Plugin for AtomPlugin {
         })
     }
 
-    fn run(&mut self, ports: &mut Ports, _: &mut ()) {
+    fn run(&mut self, ports: &mut Ports, _: &mut (), _: u32) {
         let sequence_reader = ports
             .input
             .read::<Sequence>(self.urids.atom.sequence, self.urids.units.beat)

--- a/core/src/extension.rs
+++ b/core/src/extension.rs
@@ -79,7 +79,7 @@
 //!         Some(Self { internal: 0 })
 //!     }
 //!
-//!     fn run(&mut self, _: &mut (), _: &mut ()) {
+//!     fn run(&mut self, _: &mut (), _: &mut (), _: u32) {
 //!         self.internal += 1;
 //!     }
 //!

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //!     // Process a chunk of audio. The audio ports are dereferenced to slices, which the plugin
 //!     // iterates over.
-//!     fn run(&mut self, ports: &mut Ports, _features: &mut ()) {
+//!     fn run(&mut self, ports: &mut Ports, _features: &mut (), _: u32) {
 //!         let coef = if *(ports.gain) > -90.0 {
 //!             10.0_f32.powf(*(ports.gain) * 0.05)
 //!         } else {

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -45,7 +45,12 @@ pub trait Plugin: UriBound + Sized + Send + Sync + 'static {
     /// Run a processing step.
     ///
     /// The host will always call this method after `active` has been called and before `deactivate` has been called.
-    fn run(&mut self, ports: &mut Self::Ports, features: &mut Self::AudioFeatures);
+    fn run(
+        &mut self,
+        ports: &mut Self::Ports,
+        features: &mut Self::AudioFeatures,
+        sample_count: u32,
+    );
 
     /// Reset and initialize the complete internal state of the plugin.
     ///
@@ -228,7 +233,7 @@ impl<T: Plugin> PluginInstance<T> {
         if let Some(mut ports) = instance.ports(sample_count) {
             instance
                 .instance
-                .run(&mut ports, &mut instance.audio_features);
+                .run(&mut ports, &mut instance.audio_features, sample_count);
         }
     }
 

--- a/core/tests/amp.rs
+++ b/core/tests/amp.rs
@@ -53,7 +53,7 @@ impl Plugin for Amp {
     }
 
     #[inline]
-    fn run(&mut self, ports: &mut AmpPorts, _: &mut ()) {
+    fn run(&mut self, ports: &mut AmpPorts, _: &mut (), _: u32) {
         assert!(self.activated);
 
         let coef = *(ports.gain);

--- a/docs/amp/src/lib.rs
+++ b/docs/amp/src/lib.rs
@@ -23,7 +23,7 @@ impl Plugin for Amp {
         Some(Self)
     }
     // The `run()` method is the main process function of the plugin. It processes a block of audio in the audio context. Since this plugin is `lv2:hardRTCapable`, `run()` must be real-time safe, so blocking (e.g. with a mutex) or memory allocation are not allowed.
-    fn run(&mut self, ports: &mut Ports, _features: &mut ()) {
+    fn run(&mut self, ports: &mut Ports, _features: &mut (), _: u32) {
         let coef = if *(ports.gain) > -90.0 {
             10.0_f32.powf(*(ports.gain) * 0.05)
         } else {

--- a/docs/fifths/src/lib.rs
+++ b/docs/fifths/src/lib.rs
@@ -38,7 +38,7 @@ impl Plugin for Fifths {
     }
 
     // This plugin works similar to the previous one: It iterates over the events in the input port. However, it only needs to write one or two messages instead of blocks of audio.
-    fn run(&mut self, ports: &mut Ports, _: &mut ()) {
+    fn run(&mut self, ports: &mut Ports, _: &mut (), _: u32) {
         // Get the reading handle of the input sequence.
         let input_sequence = ports
             .input

--- a/docs/metro/src/lib.rs
+++ b/docs/metro/src/lib.rs
@@ -74,7 +74,7 @@ impl Plugin for Metro {
         self.sampler.reset();
     }
 
-    fn run(&mut self, ports: &mut Ports, _: &mut ()) {
+    fn run(&mut self, ports: &mut Ports, _: &mut (), _: u32) {
         if let Some(control) = ports
             .control
             .read(self.urids.atom.sequence, self.urids.unit.beat)

--- a/docs/midigate/src/lib.rs
+++ b/docs/midigate/src/lib.rs
@@ -77,7 +77,7 @@ impl Plugin for Midigate {
     // This pattern of iterating over input events and writing output along the way is a common idiom for writing sample accurate output based on event input.
     //
     // Note that this simple example simply writes input or zero for each sample based on the gate. A serious implementation would need to envelope the transition to avoid aliasing.
-    fn run(&mut self, ports: &mut Ports, _: &mut ()) {
+    fn run(&mut self, ports: &mut Ports, _: &mut (), _: u32) {
         let mut offset: usize = 0;
 
         let control_sequence = ports

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //!
 //!     // Process a chunk of audio. The audio ports are dereferenced to slices, which the plugin
 //!     // iterates over.
-//!     fn run(&mut self, ports: &mut Ports, _features: &mut ()) {
+//!     fn run(&mut self, ports: &mut Ports, _features: &mut (), _: u32) {
 //!         let coef = if *(ports.gain) > -90.0 {
 //!             10.0_f32.powf(*(ports.gain) * 0.05)
 //!         } else {

--- a/state/src/interface.rs
+++ b/state/src/interface.rs
@@ -152,7 +152,7 @@ mod tests {
         }
 
         #[cfg_attr(tarpaulin, skip)]
-        fn run(&mut self, _: &mut (), _: &mut ()) {}
+        fn run(&mut self, _: &mut (), _: &mut (), _: u32) {}
     }
 
     #[derive(FeatureCollection)]

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -59,7 +59,7 @@
 //!         })
 //!     }
 //!
-//!     fn run(&mut self, _: &mut (), _: &mut ()) {
+//!     fn run(&mut self, _: &mut (), _: &mut (), _: u32) {
 //!         // Set the float to a different value than the previous one.
 //!         self.internal += 1.0;
 //!     }

--- a/state/src/path.rs
+++ b/state/src/path.rs
@@ -65,7 +65,7 @@
 //! #         })
 //! #     }
 //! #
-//! #     fn run(&mut self, _: &mut (), _: &mut ()) {}
+//! #     fn run(&mut self, _: &mut (), _: &mut (), _: u32) {}
 //! # }
 //!
 //! impl State for Sampler {

--- a/state/tests/integration.rs
+++ b/state/tests/integration.rs
@@ -36,7 +36,7 @@ impl Plugin for Stateful {
         })
     }
 
-    fn run(&mut self, _: &mut (), _: &mut ()) {
+    fn run(&mut self, _: &mut (), _: &mut (), _: u32) {
         self.internal = 17.0;
         self.audio.extend((0..32).map(|f| f as f32));
     }
@@ -118,7 +118,7 @@ fn test_save_n_restore() {
 
     let mut first_plugin = create_plugin(mapper.as_mut());
 
-    first_plugin.run(&mut (), &mut ());
+    first_plugin.run(&mut (), &mut (), 32);
 
     assert_eq!(17.0, first_plugin.internal);
     assert_eq!(32, first_plugin.audio.len());

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -54,7 +54,7 @@
 //!        })
 //!    }
 //!
-//!    fn run(&mut self, _ports: &mut Ports, features: &mut Self::AudioFeatures) {
+//!    fn run(&mut self, _ports: &mut Ports, features: &mut Self::AudioFeatures, _: u32) {
 //!        self.cycle += 1;
 //!        let cycle = self.cycle;
 //!        println!("cycle {} started", cycle);
@@ -531,7 +531,7 @@ mod tests {
             Some(Self {})
         }
 
-        fn run(&mut self, _ports: &mut Ports, _features: &mut Self::InitFeatures) {}
+        fn run(&mut self, _ports: &mut Ports, _features: &mut Self::InitFeatures, _: u32) {}
     }
 
     impl Worker for TestDropWorker {


### PR DESCRIPTION
This adds `sample_count` to the Plugin trait. This is necessary if the plugin needs to be correct regarding samples/frames, but has no audio port and no direct access to the number of frames (e.g. a sequencing plugin which has just midi ports, but needs to emit events at exact frames).

See also #87 for discussion.