### PR TITLE
Add allow(non_camel_case_types) to generated type

### DIFF
--- a/core/derive/src/port_collection_derive.rs
+++ b/core/derive/src/port_collection_derive.rs
@@ -128,7 +128,7 @@ impl<'a> PortCollectionStruct<'a> {
             }
 
             #[doc(hidden)]
-            #[allow(non_snake_case)]
+            #[allow(non_snake_case, non_camel_case_types)]
             pub struct #internal_cache_name {
                 #(#raw_field_declarations)*
             }


### PR DESCRIPTION
Currently, rust-analyzer complains:
```
Structure `__lv2_plugin_ports_derive_Ports_PortPointerCache` should have CamelCase name, e.g. `Lv2PluginPortsDerivePortsPortPointerCache`
```

As of [this commit](https://github.com/rust-analyzer/rust-analyzer/pull/6421/files), rust-analyzer will honor `allow(non_camel_case_types)`, so I'm trying to add it here. I have no idea if this actually works though.