### PR TITLE
fix offset calculation in midigate

### DIFF
--- a/docs/midigate/src/lib.rs
+++ b/docs/midigate/src/lib.rs
@@ -111,7 +111,7 @@ impl Plugin for Midigate {
             }
 
             self.write_output(ports, offset, timestamp + offset);
-            offset += timestamp;
+            offset = timestamp;
         }
 
         self.write_output(ports, offset, ports.input.len() - offset);


### PR DESCRIPTION
Hi, found and fixed an error in midigate example. This error result in crash with the following conditions:
host : jalv or ardour, with inPlaceBroken removed from the midigate.ttl for the test.
sending many notes to the plugin. Making a "glissando" with Jack keyboard is generally enough