### PR TITLE
Fix deref

### DIFF
--- a/atom/src/port.rs
+++ b/atom/src/port.rs
@@ -110,15 +110,23 @@ impl PortType for AtomPort {
     type OutputPortType = PortWriter<'static>;
 
     #[inline]
-    unsafe fn input_from_raw(pointer: NonNull<c_void>, _sample_count: u32) -> PortReader<'static> {
-        let header = AtomHeader::from_raw(pointer.cast().as_ref());
-        PortReader::new(UnidentifiedAtom::from_header(header))
+    unsafe fn input_from_raw(
+        pointer: NonNull<c_void>,
+        _sample_count: u32,
+    ) -> *const PortReader<'static> {
+        todo!();
+        //let header = AtomHeader::from_raw(pointer.cast().as_ref());
+        //PortReader::new(UnidentifiedAtom::from_header(header))
     }
 
     #[inline]
-    unsafe fn output_from_raw(pointer: NonNull<c_void>, _sample_count: u32) -> PortWriter<'static> {
-        let header = AtomHeader::from_raw_mut(pointer.cast().as_mut());
-        PortWriter::new(UnidentifiedAtom::from_header_mut(header).body_mut())
+    unsafe fn output_from_raw(
+        pointer: NonNull<c_void>,
+        _sample_count: u32,
+    ) -> *mut PortWriter<'static> {
+        todo!();
+        //let header = AtomHeader::from_raw_mut(pointer.cast().as_mut());
+        //PortWriter::new(UnidentifiedAtom::from_header_mut(header).body_mut())
     }
 }
 

--- a/core/src/feature/mod.rs
+++ b/core/src/feature/mod.rs
@@ -9,6 +9,8 @@ pub use cache::FeatureCache;
 pub use core_features::*;
 pub use descriptor::FeatureDescriptor;
 
+pub use lv2_core_derive::FeatureCollection;
+
 use std::ffi::c_void;
 
 /// All threading contexts of LV2 interface methods.

--- a/core/src/feature/mod.rs
+++ b/core/src/feature/mod.rs
@@ -9,6 +9,7 @@ pub use cache::FeatureCache;
 pub use core_features::*;
 pub use descriptor::FeatureDescriptor;
 
+#[cfg(feature = "lv2-core-derive")]
 pub use lv2_core_derive::FeatureCollection;
 
 use std::ffi::c_void;

--- a/core/src/port.rs
+++ b/core/src/port.rs
@@ -21,9 +21,9 @@ pub use lv2_core_derive::*;
 /// A port can read input or create a pointer to the output, but the exact type of input/output (pointer) depends on the type of port. This trait generalizes these types and behaviour.
 pub trait PortType {
     /// The type of input read by the port.
-    type InputPortType: Sized;
+    type InputPortType: ?Sized;
     /// The type of output reference created by the port.
-    type OutputPortType: Sized;
+    type OutputPortType: ?Sized;
 
     /// Read data from the pointer or create a reference to the input.
     ///
@@ -32,7 +32,10 @@ pub trait PortType {
     /// # Safety
     ///
     /// This method is unsafe because one needs to de-reference a raw pointer to implement this method.
-    unsafe fn input_from_raw(pointer: NonNull<c_void>, sample_count: u32) -> Self::InputPortType;
+    unsafe fn input_from_raw(
+        pointer: NonNull<c_void>,
+        sample_count: u32,
+    ) -> *const Self::InputPortType;
 
     /// Create a reference to the data where output should be written to.
     ///
@@ -41,7 +44,10 @@ pub trait PortType {
     /// # Safety
     ///
     /// This method is unsafe because one needs to de-reference a raw pointer to implement this method.
-    unsafe fn output_from_raw(pointer: NonNull<c_void>, sample_count: u32) -> Self::OutputPortType;
+    unsafe fn output_from_raw(
+        pointer: NonNull<c_void>,
+        sample_count: u32,
+    ) -> *mut Self::OutputPortType;
 }
 
 /// Abstraction of safe port handles.
@@ -60,7 +66,7 @@ pub trait PortHandle: Sized {
 ///
 /// Fields of this type can be dereferenced to the input type of the port type.
 pub struct InputPort<T: PortType> {
-    port: T::InputPortType,
+    port: *const T::InputPortType,
 }
 
 impl<T: PortType> Deref for InputPort<T> {
@@ -68,11 +74,14 @@ impl<T: PortType> Deref for InputPort<T> {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        &self.port
+        unsafe { &*self.port }
     }
 }
 
-impl<T: PortType> PortHandle for InputPort<T> {
+impl<T> PortHandle for InputPort<T>
+where
+    T: PortType,
+{
     #[inline]
     unsafe fn from_raw(pointer: *mut c_void, sample_count: u32) -> Option<Self> {
         Some(Self {
@@ -85,7 +94,7 @@ impl<T: PortType> PortHandle for InputPort<T> {
 ///
 /// Fields of this type can be dereferenced to the output type of the port type.
 pub struct OutputPort<T: PortType> {
-    port: T::OutputPortType,
+    port: *mut T::OutputPortType,
 }
 
 impl<T: PortType> Deref for OutputPort<T> {
@@ -93,14 +102,14 @@ impl<T: PortType> Deref for OutputPort<T> {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        &self.port
+        unsafe { &*self.port }
     }
 }
 
 impl<T: PortType> DerefMut for OutputPort<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.port
+        unsafe { &mut *self.port }
     }
 }
 

--- a/core/src/port.rs
+++ b/core/src/port.rs
@@ -13,9 +13,6 @@ use std::ffi::c_void;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
-#[cfg(feature = "lv2-core-derive")]
-pub use lv2_core_derive::*;
-
 /// Generalization of port types.
 ///
 /// A port can read input or create a pointer to the output, but the exact type of input/output (pointer) depends on the type of port. This trait generalizes these types and behaviour.
@@ -135,7 +132,8 @@ impl<T: PortHandle> PortHandle for Option<T> {
 /// # Implementing
 ///
 /// The most convenient way to create a port collections is to define a struct with port types from the [`port`](index.html) module and then simply derive `PortCollection` for it. An example:
-///
+/// ```
+///     # pub use lv2_core_derive::*;
 ///     use lv2_core::port::*;
 ///
 ///     #[derive(PortCollection)]
@@ -146,6 +144,7 @@ impl<T: PortHandle> PortHandle for Option<T> {
 ///         control_output: OutputPort<Control>,
 ///         optional_control_input: Option<InputPort<Control>>,
 ///     }
+/// ```
 ///
 /// Please note that port indices are mapped in the order of occurrence; In our example, the implementation will treat `audio_input` as port `0`, `audio_output` as port `1` and so on. Therefore, your plugin definition and your port collection have to match. Otherwise, undefined behaviour will occur.
 pub trait PortCollection: Sized {

--- a/core/src/port/audio.rs
+++ b/core/src/port/audio.rs
@@ -66,16 +66,22 @@ unsafe impl UriBound for Audio {
 }
 
 impl PortType for Audio {
-    type InputPortType = &'static [f32];
-    type OutputPortType = &'static mut [f32];
+    type InputPortType = [f32];
+    type OutputPortType = [f32];
 
     #[inline]
-    unsafe fn input_from_raw(pointer: NonNull<c_void>, sample_count: u32) -> Self::InputPortType {
+    unsafe fn input_from_raw(
+        pointer: NonNull<c_void>,
+        sample_count: u32,
+    ) -> *const Self::InputPortType {
         std::slice::from_raw_parts(pointer.as_ptr() as *const f32, sample_count as usize)
     }
 
     #[inline]
-    unsafe fn output_from_raw(pointer: NonNull<c_void>, sample_count: u32) -> Self::OutputPortType {
+    unsafe fn output_from_raw(
+        pointer: NonNull<c_void>,
+        sample_count: u32,
+    ) -> *mut Self::OutputPortType {
         std::slice::from_raw_parts_mut(pointer.as_ptr() as *mut f32, sample_count as usize)
     }
 }
@@ -132,11 +138,15 @@ unsafe impl UriBound for InPlaceAudio {
 }
 
 impl PortType for InPlaceAudio {
-    type InputPortType = &'static [Cell<f32>];
-    type OutputPortType = &'static [Cell<f32>];
+    type InputPortType = [Cell<f32>];
+    type OutputPortType = [Cell<f32>];
 
     #[inline]
-    unsafe fn input_from_raw(pointer: NonNull<c_void>, sample_count: u32) -> Self::InputPortType {
+    unsafe fn input_from_raw(
+        pointer: NonNull<c_void>,
+        sample_count: u32,
+    ) -> *const Self::InputPortType {
+        //std::slice::from_raw_parts(pointer.as_ptr() as *const Cell<f32>, sample_count as usize)
         Cell::from_mut(std::slice::from_raw_parts_mut(
             pointer.as_ptr() as *mut f32,
             sample_count as usize,
@@ -145,11 +155,15 @@ impl PortType for InPlaceAudio {
     }
 
     #[inline]
-    unsafe fn output_from_raw(pointer: NonNull<c_void>, sample_count: u32) -> Self::OutputPortType {
-        Cell::from_mut(std::slice::from_raw_parts_mut(
-            pointer.as_ptr() as *mut f32,
-            sample_count as usize,
-        ))
-        .as_slice_of_cells()
+    unsafe fn output_from_raw(
+        pointer: NonNull<c_void>,
+        sample_count: u32,
+    ) -> *mut Self::OutputPortType {
+        std::slice::from_raw_parts_mut(pointer.as_ptr() as *mut Cell<f32>, sample_count as usize)
+        //Cell::from_mut(std::slice::from_raw_parts_mut(
+        //    pointer.as_ptr() as *mut f32,
+        //    sample_count as usize,
+        //))
+        //.as_slice_of_cells()
     }
 }

--- a/core/src/port/control.rs
+++ b/core/src/port/control.rs
@@ -66,16 +66,16 @@ unsafe impl UriBound for Control {
 
 impl PortType for Control {
     type InputPortType = f32;
-    type OutputPortType = &'static mut f32;
+    type OutputPortType = f32;
 
     #[inline]
-    unsafe fn input_from_raw(pointer: NonNull<c_void>, _sample_count: u32) -> f32 {
-        *(pointer.cast().as_ref())
+    unsafe fn input_from_raw(pointer: NonNull<c_void>, _sample_count: u32) -> *const f32 {
+        pointer.as_ptr() as *const f32
     }
 
     #[inline]
-    unsafe fn output_from_raw(pointer: NonNull<c_void>, _sample_count: u32) -> &'static mut f32 {
-        (pointer.as_ptr() as *mut f32).as_mut().unwrap()
+    unsafe fn output_from_raw(pointer: NonNull<c_void>, _sample_count: u32) -> *mut f32 {
+        pointer.as_ptr() as *mut f32
     }
 }
 
@@ -130,19 +130,22 @@ unsafe impl UriBound for InPlaceControl {
 }
 
 impl PortType for InPlaceControl {
-    type InputPortType = &'static Cell<f32>;
-    type OutputPortType = &'static Cell<f32>;
+    type InputPortType = Cell<f32>;
+    type OutputPortType = Cell<f32>;
 
     #[inline]
-    unsafe fn input_from_raw(pointer: NonNull<c_void>, _sample_count: u32) -> Self::InputPortType {
-        Cell::from_mut(&mut *(pointer.as_ptr() as *mut f32))
+    unsafe fn input_from_raw(
+        pointer: NonNull<c_void>,
+        _sample_count: u32,
+    ) -> *const Self::InputPortType {
+        pointer.as_ptr() as _
     }
 
     #[inline]
     unsafe fn output_from_raw(
         pointer: NonNull<c_void>,
         _sample_count: u32,
-    ) -> Self::OutputPortType {
-        Cell::from_mut(&mut *(pointer.as_ptr() as *mut f32))
+    ) -> *mut Self::OutputPortType {
+        pointer.as_ptr() as _
     }
 }

--- a/core/src/port/cv.rs
+++ b/core/src/port/cv.rs
@@ -79,16 +79,22 @@ unsafe impl UriBound for CV {
 }
 
 impl PortType for CV {
-    type InputPortType = &'static [f32];
-    type OutputPortType = &'static mut [f32];
+    type InputPortType = [f32];
+    type OutputPortType = [f32];
 
     #[inline]
-    unsafe fn input_from_raw(pointer: NonNull<c_void>, sample_count: u32) -> Self::InputPortType {
+    unsafe fn input_from_raw(
+        pointer: NonNull<c_void>,
+        sample_count: u32,
+    ) -> *const Self::InputPortType {
         std::slice::from_raw_parts(pointer.as_ptr() as *const f32, sample_count as usize)
     }
 
     #[inline]
-    unsafe fn output_from_raw(pointer: NonNull<c_void>, sample_count: u32) -> Self::OutputPortType {
+    unsafe fn output_from_raw(
+        pointer: NonNull<c_void>,
+        sample_count: u32,
+    ) -> *mut Self::OutputPortType {
         std::slice::from_raw_parts_mut(pointer.as_ptr() as *mut f32, sample_count as usize)
     }
 }
@@ -158,24 +164,22 @@ unsafe impl UriBound for InPlaceCV {
 }
 
 impl PortType for InPlaceCV {
-    type InputPortType = &'static [Cell<f32>];
-    type OutputPortType = &'static [Cell<f32>];
+    type InputPortType = [Cell<f32>];
+    type OutputPortType = [Cell<f32>];
 
     #[inline]
-    unsafe fn input_from_raw(pointer: NonNull<c_void>, sample_count: u32) -> Self::InputPortType {
-        Cell::from_mut(std::slice::from_raw_parts_mut(
-            pointer.as_ptr() as *mut f32,
-            sample_count as usize,
-        ))
-        .as_slice_of_cells()
+    unsafe fn input_from_raw(
+        pointer: NonNull<c_void>,
+        sample_count: u32,
+    ) -> *const Self::InputPortType {
+        std::slice::from_raw_parts(pointer.as_ptr() as *const Cell<f32>, sample_count as usize)
     }
 
     #[inline]
-    unsafe fn output_from_raw(pointer: NonNull<c_void>, sample_count: u32) -> Self::OutputPortType {
-        Cell::from_mut(std::slice::from_raw_parts_mut(
-            pointer.as_ptr() as *mut f32,
-            sample_count as usize,
-        ))
-        .as_slice_of_cells()
+    unsafe fn output_from_raw(
+        pointer: NonNull<c_void>,
+        sample_count: u32,
+    ) -> *mut Self::OutputPortType {
+        std::slice::from_raw_parts_mut(pointer.as_ptr() as *mut Cell<f32>, sample_count as usize)
     }
 }


### PR DESCRIPTION
I already mentioned it elsewhere, few time ago i discovered that the port system and especially the dereferentiation mechanism was wrongly implemented, so i started to fix it. This fix would solve #95 and make ports safer. Every reference gotten from ports inside run context couldn't outlive this context. However, ports themself may moved out from run context, but i actually didn't find a way.

Current state: 
 - port system and ports are fixed in lv2_core.
 - atom ports are broken, i just did a hack to be able to compile anyway. I will try to fix soon but i may need help for that, i'm unable to understand how the whole thing work internally.

EDIT: forgot to mention, a new issue appear with this fix,  "inplace output" ports can produce mutable reference, which is bad. This is not addressed here because this require to modify some design choice about ports.