### PR TITLE
Shrink unsafe block for the VectorWriter impl

### DIFF
--- a/atom/src/vector.rs
+++ b/atom/src/vector.rs
@@ -127,12 +127,12 @@ impl<'a, 'b, A: ScalarAtom> VectorWriter<'a, 'b, A> {
         };
         self.frame
             .allocate(raw_data.len(), false)
-            .map(|(_, space)| unsafe {
+            .map(|(_, space)| {
                 space.copy_from_slice(raw_data);
-                std::slice::from_raw_parts_mut(
+                unsafe { std::slice::from_raw_parts_mut(
                     space.as_mut_ptr() as *mut A::InternalType,
                     data.len(),
-                )
+                ) }
             })
     }
 }

--- a/urid/src/lib.rs
+++ b/urid/src/lib.rs
@@ -384,12 +384,12 @@ impl Unmap for HashURIDMapper {
                 // This is safe because the only way this reference might become invalid is if an
                 // entry gets overwritten, which is not something that we allow through this
                 // interface.
-                return Some(unsafe {
+                return Some({
                     let bytes = uri.as_bytes_with_nul();
-                    Uri::from_bytes_with_nul_unchecked(std::slice::from_raw_parts(
+                    unsafe { Uri::from_bytes_with_nul_unchecked(std::slice::from_raw_parts(
                         bytes.as_ptr(),
                         bytes.len(),
-                    ))
+                    )) }
                 });
             }
         }


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions. However, I found that only 2 functions are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the from_bytes_with_nul_unchecked()/from_raw_parts_mut() function(these are unsafe functions)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 