### PR TITLE
Use linux module for macOS too

### DIFF
--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(rustdoc::bare_urls)]
 
 #[cfg_attr(target_os = "linux", path = "linux/mod.rs")]
+#[cfg_attr(target_os = "macos", path = "linux/mod.rs")]
 #[cfg_attr(target_os = "windows", path = "windows.rs")]
 mod unsupported;
 pub use unsupported::*;


### PR DESCRIPTION
With this change, I was able to successfully compile https://github.com/chadmed/bankstown (having patched its `Cargo.toml` to point to my local working copy of `rust-lv2`) on an Apple Silicon Mac, and run it in Carla 2.5.8.

Maybe `linux` should be renamed `unix`? I can do that work too.